### PR TITLE
Fix install paths

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -162,6 +162,7 @@ if(SYMFORCE_USE_EXTERNAL_LCM)
   add_library(symforce_lcmtypes_cpp INTERFACE)
   target_link_libraries(symforce_lcmtypes_cpp ${SYMFORCE_LCMTYPES_TARGET})
 else()
+  add_subdirectory(third_party/skymarshal)
   include(third_party/skymarshal/cmake/skymarshal.cmake)
 
   add_skymarshal_bindings(symforce_lcmtypes
@@ -224,7 +225,7 @@ target_include_directories(
 )
 
 install(TARGETS symforce_gen DESTINATION lib)
-install(FILES ${SYMFORCE_GEN_HEADERS} DESTINATION include)
+install(DIRECTORY gen/cpp/ DESTINATION include FILES_MATCHING PATTERN "*.h" PATTERN "*.tcc")
 
 if(SYMFORCE_BUILD_OPT)
   add_subdirectory(symforce/opt)

--- a/symforce/opt/CMakeLists.txt
+++ b/symforce/opt/CMakeLists.txt
@@ -129,9 +129,6 @@ add_library(
 target_link_libraries(symforce_cholesky metis ${SYMFORCE_EIGEN_TARGET})
 target_include_directories(symforce_cholesky PUBLIC ../..)
 
-install(TARGETS symforce_cholesky DESTINATION lib)
-install(FILES ${SYMFORCE_CHOLESKY_HEADERS} DESTINATION include)
-
 # ------------------------------------------------------------------------------
 # symforce_opt
 
@@ -152,9 +149,6 @@ target_link_libraries(symforce_opt
   ${SYMFORCE_EIGEN_TARGET}
 )
 
-install(TARGETS symforce_opt DESTINATION lib)
-install(FILES ${SYMFORCE_OPT_HEADERS} DESTINATION include)
-
 if(SYMFORCE_CUSTOM_TIC_TOCS)
   target_link_libraries(symforce_opt ${SYMFORCE_TIC_TOC_TARGET})
   target_compile_definitions(symforce_opt
@@ -162,3 +156,11 @@ if(SYMFORCE_CUSTOM_TIC_TOCS)
     PUBLIC SYM_TIME_SCOPE=${SYMFORCE_TIC_TOC_MACRO}
   )
 endif(SYMFORCE_CUSTOM_TIC_TOCS)
+
+
+# ------------------------------------------------------------------------------
+# install
+
+install(TARGETS symforce_cholesky DESTINATION lib)
+install(TARGETS symforce_opt DESTINATION lib)
+install(DIRECTORY ./ DESTINATION include/symforce/opt FILES_MATCHING PATTERN "*.h" PATTERN "*.tcc")

--- a/third_party/skymarshal/CMakeLists.txt
+++ b/third_party/skymarshal/CMakeLists.txt
@@ -3,3 +3,4 @@ project(skymarshal)
 
 add_library(skymarshal_core INTERFACE include/lcm/lcm_coretypes.h)
 target_include_directories(skymarshal_core INTERFACE include)
+install(DIRECTORY include/ DESTINATION include)

--- a/third_party/skymarshal/cmake/skymarshal.cmake
+++ b/third_party/skymarshal/cmake/skymarshal.cmake
@@ -53,14 +53,15 @@ function(add_cpp_bindings
 
   foreach(package_and_type ${types_to_generate})
     get_package_and_type(${package_and_type} package type)
-    list(APPEND generated_files ${bindings_dir}/cpp/lcmtypes/${package}/${type}.hpp)
+    set(generated_file ${bindings_dir}/cpp/lcmtypes/${package}/${type}.hpp)
+    list(APPEND generated_files ${generated_file})
+
+    install(FILES ${generated_file} DESTINATION include/lcmtypes/${package})
   endforeach()
 
   add_library(${target_name}_cpp INTERFACE ${generated_files})
-  target_include_directories(${target_name}_cpp INTERFACE ${bindings_dir}/cpp ${CMAKE_CURRENT_SOURCE_DIR}/third_party/lcm)
+  target_include_directories(${target_name}_cpp INTERFACE ${bindings_dir}/cpp)
   target_link_libraries(${target_name}_cpp INTERFACE skymarshal_core)
-
-  install(FILES ${generated_files} DESTINATION include)
 
   set(${generated_files_outvar} ${generated_files} PARENT_SCOPE)
 


### PR DESCRIPTION
Previously we were installing all our headers into `include`, instead of
preserving the directory structure in there.  This breaks lots of
things, for instance we create an `assert.h` that'll break things
attempting to include the stdlib `assert.h`.

This preserves directory structure correctly when running `cmake
--build --target install` (and therefore also `pip install .`,
which calls cmake).  Tested locally in a conda environment.