### PR TITLE
Add find_package(spdlog) to CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -267,6 +267,7 @@ endif()
 # the lcm-gen executable and symengine.
 
 if(SYMFORCE_GENERATE_MANIFEST)
+  find_package(spdlog REQUIRED)
   function(generate_manifest)
     get_target_property(eigen_include_dirs ${SYMFORCE_EIGEN_TARGET} INTERFACE_INCLUDE_DIRECTORIES)
     get_target_property(spdlog_include_dirs spdlog::spdlog INTERFACE_INCLUDE_DIRECTORIES)


### PR DESCRIPTION
On macOS (possibly others), the brew-installed spdlog and its CMake targets are
not automatically available without first calling find_package(spdlog).  This
commit adds that call.