### PR TITLE
Bump default pybind to 2.9.2

### DIFF
--- a/symforce/pybind/CMakeLists.txt
+++ b/symforce/pybind/CMakeLists.txt
@@ -11,7 +11,7 @@ if (NOT pybind11_FOUND)
   FetchContent_Declare(
     pybind11
     GIT_REPOSITORY https://github.com/pybind/pybind11
-    GIT_TAG e7c9753f1d35061d137ac3ce561e94a7407e5583 # release 2.8.1
+    GIT_TAG 914c06fb252b6cc3727d0eedab6736e88a3fcb01 # release 2.9.2
   )
   FetchContent_MakeAvailable(pybind11)
 else()


### PR DESCRIPTION
Hi symforce team,

Seems that pybind 2.8.1 cannot be used for symforce project, we'll meet compatibility issues such as belows if we use pybind 2.8.1, so I bump pybind to 2.9.2 in this PR

```sh
    /home/zhiqiang/coding/symforce/build/temp.linux-x86_64-cpython-38/_deps/pybind11-src/include/pybind11/eigen.h: In member function ‘bool pybind11::detail::type_caster<Type, typename std::enable_if<decltype (pybind11::detail::is_template_base_of_impl<Eigen::SparseMatrixBase>::check((typename pybind11::detail::intrinsic_type<T>::type*)(nullptr)))::value, void>::type>::load(pybind11::handle, bool)’:
    /home/zhiqiang/coding/symforce/build/temp.linux-x86_64-cpython-38/_deps/pybind11-src/include/pybind11/eigen.h:576:24: error: ‘MappedSparseMatrix’ is not a member of ‘Eigen’; did you mean ‘SparseMatrix’?
      576 |         value = Eigen::MappedSparseMatrix<Scalar,
          |                        ^~~~~~~~~~~~~~~~~~
          |                        SparseMatrix
    /home/zhiqiang/coding/symforce/build/temp.linux-x86_64-cpython-38/_deps/pybind11-src/include/pybind11/eigen.h:576:49: error: expected primary-expression before ‘,’ token
      576 |         value = Eigen::MappedSparseMatrix<Scalar,
          |                                                 ^
    /home/zhiqiang/coding/symforce/build/temp.linux-x86_64-cpython-38/_deps/pybind11-src/include/pybind11/eigen.h:578:55: error: expected primary-expression before ‘>’ token
      578 |                                           StorageIndex>(
          |                                                       ^
```