### PR TITLE
Add geo and cam classes to symforce.sympy

### DIFF
--- a/symforce/__init__.py
+++ b/symforce/__init__.py
@@ -69,12 +69,12 @@ from . import initialization
 
 
 def _set_backend(sympy_module: ModuleType) -> None:
-    # Make symforce-specific modifications to the sympy API
-    initialization.modify_symbolic_api(sympy_module)
-
     # Set this as the default backend
     global sympy  # pylint: disable=global-statement
     sympy = sympy_module
+
+    # Make symforce-specific modifications to the sympy API
+    initialization.modify_symbolic_api(sympy_module)
 
 
 def _import_symengine_from_build() -> ModuleType:


### PR DESCRIPTION
Not adding geo.Matrix, since it collides with sympy.Matrix.  Not sure what we want to do there.

Tested locally, switching back and forth a bunch between the backends and verifying that `type(sm.Rot3().q.xyz[0])` was correct (either a sympy or symengine constant).

Fixes #106
