### PR TITLE
Emit a warning if optimizing factors that don't touch any keys

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -114,6 +114,10 @@ if(SYMFORCE_BUILD_CC_SYM
   endif()
 endif()
 
+if(SYMFORCE_BUILD_TESTS AND NOT SYMFORCE_BUILD_EXAMPLES)
+  message(FATAL_ERROR "Attempting to build tests without building examples, which is not supported")
+endif()
+
 # ==============================================================================
 # Third Party Dependencies (needed for build)
 # ==============================================================================

--- a/symforce/opt/linearizer.cc
+++ b/symforce/opt/linearizer.cc
@@ -15,9 +15,10 @@ namespace sym {
 // ----------------------------------------------------------------------------
 
 template <typename ScalarType>
-Linearizer<ScalarType>::Linearizer(const std::vector<Factor<Scalar>>& factors,
+Linearizer<ScalarType>::Linearizer(const std::string& name,
+                                   const std::vector<Factor<Scalar>>& factors,
                                    const std::vector<Key>& key_order)
-    : factors_(&factors), dense_linearized_factors_(), sparse_linearized_factors_() {
+    : name_(name), factors_(&factors), dense_linearized_factors_(), sparse_linearized_factors_() {
   if (key_order.empty()) {
     keys_ = ComputeKeysToOptimize(factors);
   } else {
@@ -140,7 +141,7 @@ void Linearizer<ScalarType>::InitializeStorageAndIndices() {
     dense_factor_update_helpers_.push_back(
         internal::ComputeFactorHelper<Scalar, typename Factor<Scalar>::LinearizedDenseFactor,
                                       linearization_dense_factor_helper_t>(
-            factor, state_index_, combined_residual_offset));
+            factor, state_index_, name_, combined_residual_offset));
   }
 
   // This will put all the sparse factors at the end of the combined residual, which may not be
@@ -150,7 +151,7 @@ void Linearizer<ScalarType>::InitializeStorageAndIndices() {
     sparse_factor_update_helpers_.push_back(
         internal::ComputeFactorHelper<Scalar, typename Factor<Scalar>::LinearizedSparseFactor,
                                       linearization_sparse_factor_helper_t>(
-            factor, state_index_, combined_residual_offset));
+            factor, state_index_, name_, combined_residual_offset));
   }
 
   // Sanity check

--- a/symforce/opt/linearizer.h
+++ b/symforce/opt/linearizer.h
@@ -43,7 +43,8 @@ class Linearizer {
    *                factor keys. If not provided, it is computed from all keys for all
    *                factors using a default ordering.
    */
-  Linearizer(const std::vector<Factor<Scalar>>& factors, const std::vector<Key>& key_order = {});
+  Linearizer(const std::string& name, const std::vector<Factor<Scalar>>& factors,
+             const std::vector<Key>& key_order = {});
 
   /**
    * Update linearization at a new evaluation point. Returns the total residual dimension M.
@@ -154,6 +155,9 @@ class Linearizer {
 
   bool initialized_{false};
 
+  // The name of this linearizer to be used for printing debug information.
+  std::string name_;
+
   // Pointer to the nonlinear factors
   const std::vector<Factor<Scalar>>* factors_;
 
@@ -178,9 +182,11 @@ class Linearizer {
 template <typename Scalar>
 Linearization<Scalar> Linearize(const std::vector<Factor<Scalar>>& factors,
                                 const Values<Scalar>& values,
-                                const std::vector<Key>& keys_to_optimize = {}) {
+                                const std::vector<Key>& keys_to_optimize = {},
+                                const std::string& linearizer_name = "Linearizer") {
   Linearization<Scalar> linearization;
-  Linearizer<Scalar>(factors, keys_to_optimize).Relinearize(values, &linearization);
+  Linearizer<Scalar>(linearizer_name, factors, keys_to_optimize)
+      .Relinearize(values, &linearization);
   return linearization;
 }
 

--- a/symforce/opt/optimizer.tcc
+++ b/symforce/opt/optimizer.tcc
@@ -26,7 +26,7 @@ Optimizer<ScalarType, NonlinearSolverType>::Optimizer(const optimizer_params_t& 
       debug_stats_(debug_stats),
       keys_(keys.empty() ? ComputeKeysToOptimize(factors_) : keys),
       index_(),
-      linearizer_(factors_, keys_),
+      linearizer_(name_, factors_, keys_),
       linearize_func_(BuildLinearizeFunc(check_derivatives)) {}
 
 template <typename ScalarType, typename NonlinearSolverType>
@@ -43,7 +43,7 @@ Optimizer<ScalarType, NonlinearSolverType>::Optimizer(
       debug_stats_(debug_stats),
       keys_(keys.empty() ? ComputeKeysToOptimize(factors_) : keys),
       index_(),
-      linearizer_(factors_, keys_),
+      linearizer_(name_, factors_, keys_),
       linearize_func_(BuildLinearizeFunc(check_derivatives)) {}
 
 template <typename ScalarType, typename NonlinearSolverType>
@@ -59,7 +59,7 @@ Optimizer<ScalarType, NonlinearSolverType>::Optimizer(const optimizer_params_t& 
       debug_stats_(debug_stats),
       keys_(keys.empty() ? ComputeKeysToOptimize(factors_) : std::move(keys)),
       index_(),
-      linearizer_(factors_, keys_),
+      linearizer_(name_, factors_, keys_),
       linearize_func_(BuildLinearizeFunc(check_derivatives)) {}
 
 template <typename ScalarType, typename NonlinearSolverType>
@@ -75,7 +75,7 @@ Optimizer<ScalarType, NonlinearSolverType>::Optimizer(
       debug_stats_(debug_stats),
       keys_(keys.empty() ? ComputeKeysToOptimize(factors_) : std::move(keys)),
       index_(),
-      linearizer_(factors_, keys_),
+      linearizer_(name_, factors_, keys_),
       linearize_func_(BuildLinearizeFunc(check_derivatives)) {}
 
 // ----------------------------------------------------------------------------


### PR DESCRIPTION
For instance, if I change the symforce_optimizer_test to just optimize
one pose but still add all the factors:

```
[2022-06-15 15:03:42.358] [warning] LM<sym::Optimize>: Optimizing a factor that touches no optimized keys! Input keys for the factor are: [<FORMATTING DISABLED>]
[2022-06-15 15:03:42.358] [warning] LM<sym::Optimize>: Optimizing a factor that touches no optimized keys! Input keys for the factor are: [<FORMATTING DISABLED>]
[2022-06-15 15:03:42.358] [warning] LM<sym::Optimize>: Optimizing a factor that touches no optimized keys! Input keys for the factor are: [<FORMATTING DISABLED>, <FORMATTING DISABLED>]
[2022-06-15 15:03:42.358] [warning] LM<sym::Optimize>: Optimizing a factor that touches no optimized keys! Input keys for the factor are: [<FORMATTING DISABLED>, <FORMATTING DISABLED>]
[2022-06-15 15:03:42.358] [warning] LM<sym::Optimize>: Optimizing a factor that touches no optimized keys! Input keys for the factor are: [<FORMATTING DISABLED>, <FORMATTING DISABLED>]
[2022-06-15 15:03:42.358] [warning] LM<sym::Optimize>: Optimizing a factor that touches no optimized keys! Input keys for the factor are: [<FORMATTING DISABLED>, <FORMATTING DISABLED>]
[2022-06-15 15:03:42.358] [warning] LM<sym::Optimize>: Optimizing a factor that touches no optimized keys! Input keys for the factor are: [<FORMATTING DISABLED>, <FORMATTING DISABLED>]
[2022-06-15 15:03:42.358] [warning] LM<sym::Optimize>: Optimizing a factor that touches no optimized keys! Input keys for the factor are: [<FORMATTING DISABLED>, <FORMATTING DISABLED>]
[2022-06-15 15:03:42.358] [warning] LM<sym::Optimize>: Optimizing a factor that touches no optimized keys! Input keys for the factor are: [<FORMATTING DISABLED>, <FORMATTING DISABLED>]
```

(Side note: we need to somehow define SKYMARSHAL_PRINTING_ENABLED "by
default" or something)
