### PR TITLE
Fix spelling of word perturbation in lie-group docstrings

### DIFF
--- a/symforce/ops/interfaces/lie_group.py
+++ b/symforce/ops/interfaces/lie_group.py
@@ -48,7 +48,7 @@ class LieGroup(Group):
 
     def retract(self: LieGroupT, vec: T.Sequence[T.Scalar], epsilon: T.Scalar = 0) -> LieGroupT:
         """
-        Apply a tangent space pertubation vec to this. Often used in optimization
+        Apply a tangent space perturbation vec to this. Often used in optimization
         to update nonlinear values from an update step in the tangent space.
 
         Implementation is simply `compose(this, from_tangent(vec))`.
@@ -58,11 +58,11 @@ class LieGroup(Group):
 
     def local_coordinates(self: LieGroupT, b: LieGroupT, epsilon: T.Scalar = 0) -> T.List[T.Scalar]:
         """
-        Computes a tangent space pertubation around this to produce b. Often used in optimization
+        Computes a tangent space perturbation around this to produce b. Often used in optimization
         to minimize the distance between two group elements.
 
         Implementation is simply `to_tangent(between(this, b))`.
-        Tangent space pertubation that conceptually represents "this - a".
+        Tangent space perturbation that conceptually represents "this - a".
         """
         return self.between(b).to_tangent(epsilon=epsilon)
 

--- a/symforce/ops/lie_group_ops.py
+++ b/symforce/ops/lie_group_ops.py
@@ -63,7 +63,7 @@ class LieGroupOps(GroupOps):
 
         Args:
             a:
-            vec: Tangent space pertubation
+            vec: Tangent space perturbation
             epsilon: Small number to avoid singularity
 
         Returns:
@@ -81,7 +81,7 @@ class LieGroupOps(GroupOps):
             epsilon: Small number to avoid singularity
 
         Returns:
-            list: Tangent space pertubation around identity that approximates a.
+            list: Tangent space perturbation around identity that approximates a.
         """
         type_a = get_type(a)
         return LieGroupOps.implementation(type_a).to_tangent(a, epsilon)
@@ -89,7 +89,7 @@ class LieGroupOps(GroupOps):
     @staticmethod
     def retract(a: T.Element, vec: T.Sequence[T.Scalar], epsilon: T.Scalar = 0) -> T.Element:
         """
-        Apply a tangent space pertubation vec to the group element a. Often used in optimization
+        Apply a tangent space perturbation vec to the group element a. Often used in optimization
         to update nonlinear values from an update step in the tangent space.
 
         Implementation is simply `compose(a, from_tangent(vec))`.
@@ -107,7 +107,7 @@ class LieGroupOps(GroupOps):
     @staticmethod
     def local_coordinates(a: T.Element, b: T.Element, epsilon: T.Scalar = 0) -> T.List[T.Scalar]:
         """
-        Computes a tangent space pertubation around a to produce b. Often used in optimization
+        Computes a tangent space perturbation around a to produce b. Often used in optimization
         to minimize the distance between two group elements.
 
         Implementation is simply `to_tangent(between(a, b))`.
@@ -118,7 +118,7 @@ class LieGroupOps(GroupOps):
             epsilon: Small number to avoid singularity
 
         Returns:
-            list: Tangent space pertubation that conceptually represents "b - a"
+            list: Tangent space perturbation that conceptually represents "b - a"
         """
         return LieGroupOps.implementation(get_type(a)).local_coordinates(a, b, epsilon)
 


### PR DESCRIPTION
Minor change that corrects the spelling of the word "perturbation" in a few docstrings.