### PR TITLE
Add SymForce CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,103 @@
+name: CI
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  test-on-ubuntu:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-18.04, ubuntu-20.04]
+        python: [python3.8, python3.9, python3.10]
+        compiler: [
+          {C: gcc-5, CXX: g++-5, repos: [
+            '"deb http://dk.archive.ubuntu.com/ubuntu/ xenial main"',
+            '"deb http://dk.archive.ubuntu.com/ubuntu/ xenial universe"',
+          ]},
+          {C: gcc-11, CXX: g++-11, repos: ['"ppa:ubuntu-toolchain-r/test"']}]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      # - Installing software-properties-common adds add-apt-repository
+      - name: Update install tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y software-properties-common curl
+
+      # - Adding matrix.compiler.repos is needed to have compiler available on all ubuntu versions
+      # - Installing g++-x also installs gcc-x
+      - name: Install C and CXX compilers
+        run: |
+          for repo in ${{ join(matrix.compiler.repos, ' ') }}
+          do
+            sudo add-apt-repository -y "$repo"
+          done
+          sudo apt-get install -y ${{ matrix.compiler.CXX }}
+
+      # - ppa:deadsnakes/ppa is needed to have python3.x-dev available on all ubuntu versions
+      # - python3.x-dev is used instead of python3.x because the -dev version includes python header
+      # files needed to compile C extension modules
+      - name: Install python
+        run: |
+          sudo add-apt-repository -y ppa:deadsnakes/ppa
+          sudo apt-get install -y ${{ matrix.python }}-dev ${{ matrix.python }}-distutils
+          curl https://bootstrap.pypa.io/get-pip.py | ${{ matrix.python }}
+          pip install --upgrade setuptools
+
+      - name: Install general build dependencies
+        run: |
+            sudo apt-get install -y \
+              doxygen \
+              libgmp-dev \
+              pandoc
+
+      - name: Install build dependencies for SymForce benchmarks
+        run: |
+            sudo apt-get install -y \
+              libboost-dev \
+              libboost-serialization-dev \
+              libboost-system-dev \
+              libboost-filesystem-dev \
+              libboost-thread-dev \
+              libboost-program-options-dev \
+              libboost-date-time-dev \
+              libboost-timer-dev \
+              libboost-chrono-dev \
+              libboost-regex-dev \
+              libgoogle-glog-dev \
+              libeigen3-dev
+
+      - name: Install python dependencies
+        run: pip install -r dev_requirements.txt
+
+      - name: Run cmake build
+        run: |
+          cmake -B build \
+            -D CMAKE_C_COMPILER=${{ matrix.compiler.C }} \
+            -D CMAKE_CXX_COMPILER=${{ matrix.compiler.CXX }} \
+            -D SYMFORCE_PYTHON_OVERRIDE=${{ matrix.python }} \
+            -D SYMFORCE_BUILD_BENCHMARKS=ON
+          cmake --build build -j $(nproc)
+
+      - name: Run C++ tests
+        run: |
+          cd build
+          ctest
+
+      # - lcmtypes need to be available for tests
+      # - Exact contents of dev_requirements.txt depend on python version. Need to update file to
+      # match current python version to avoid failure of corresponding gen test. symforce needs
+      # to be on the PYTHONPATH to run gen test in this manner.
+      # - The Makefile uses the python version stored in env var PYTHON
+      - name: Run python tests
+        env:
+          PYTHON: ${{ matrix.python }}
+        run: |
+          pip install build/lcmtypes/python2.7
+          export PYTHONPATH=$PYTHONPATH:$(pwd)
+          ${{ matrix.python }} test/symforce_requirements_test.py --update
+          make -j2 test

--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,7 @@ check_types:
 		-o -path ./.eggs \
 		-o -path ./gen/python/setup.py \
 		-o -path ./test/symforce_function_codegen_test_data \
+		-o -path ./gen/python/build \
 		\) -prune -o -name "*.py" -print) \
 		--exclude "symforce/examples/.*/gen/python2\.7/lcmtypes"
 	$(MYPY_COMMAND) $(shell find test/symforce_function_codegen_test_data/sympy \

--- a/symforce/__init__.py
+++ b/symforce/__init__.py
@@ -104,7 +104,7 @@ def _find_symengine() -> ModuleType:
 
     symengine_path_candidates = list(
         symengine_install_dir.glob("lib/python3*/site-packages/symengine/__init__.py")
-    )
+    ) + list(symengine_install_dir.glob("local/lib/python3*/dist-packages/symengine/__init__.py"))
     if len(symengine_path_candidates) != 1:
         raise ImportError(
             f"Should be exactly one symengine package, found candidates {symengine_path_candidates} in directory {path_util.symenginepy_install_dir()}"


### PR DESCRIPTION
Add a github actions workflow to build SymForce and run all tests on
every combination of:
 - (ubuntu bionic `[18.04]`, ubuntu focal `[20.04]`),
 - (`gcc-7`, `gcc-11`), and
 - (`python3.8`, `python3.9`, `python3.10`)

Not tested on ubuntu jammy `[22.04]` because our vendorized version of
Catch2 does not compile on jammy (not sure why exactly).

Not testing on clang because couldn't get it to build, and figured I'd
save the task of adding clang for another day.

Not testing on mac or windows because that seems like a large enough of
a task to warrant leaving for another day.

**Some notes on what changes needed to get the build and tests working**

*Ignore build dir during make lint*

Newer versions of pip (like `22.1.2`) no longer copy the source dir into
a temporary dir, so tools like setuptools will generate their temporary
build dirs directly into the src dir.

mypy get's tripped up by the fact that there are two copies of a bunch
of modules, so we need to make sure we only tell it to lint one of them.

*Local symengine in python3.10*

For reasons that I don't fully understand, symengine is being built into
a different location when building using python3.10 than it is for
python3.9 and python3.8. So I modify `symforce.__init__.py` to make to
check this alternative location as well.