### PR TITLE
[SymForce] Run CI on push to main and build badge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,9 @@
 name: CI
 
 on:
+  push:
+    branches:
+      - 'main'
   pull_request:
     types: [opened, synchronize]
 
@@ -14,8 +17,8 @@ jobs:
         python: [python3.8, python3.9, python3.10]
         compiler: [
           {C: gcc-5, CXX: g++-5, repos: [
-            '"deb http://dk.archive.ubuntu.com/ubuntu/ xenial main"',
-            '"deb http://dk.archive.ubuntu.com/ubuntu/ xenial universe"',
+            '"deb http://us.archive.ubuntu.com/ubuntu/ xenial main"',
+            '"deb http://us.archive.ubuntu.com/ubuntu/ xenial universe"',
           ]},
           {C: gcc-11, CXX: g++-11, repos: ['"ppa:ubuntu-toolchain-r/test"']}]
     steps:

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 <!-- /DARK_MODE_ONLY -->
 
 <p align="center">
+<a href="https://github.com/symforce-org/symforce/actions/workflows/ci.yml?query=branch%3Amain"><img alt="CI status" src="https://github.com/symforce-org/symforce/actions/workflows/ci.yml/badge.svg" /></a>
 <a href="https://symforce.org"><img alt="Documentation" src="https://img.shields.io/badge/api-docs-blue" /></a>
 <a href="https://github.com/symforce-org/symforce"><img alt="Source Code" src="https://img.shields.io/badge/source-code-blue" /></a>
 <a href="https://github.com/symforce-org/symforce/issues"><img alt="Issues" src="https://img.shields.io/badge/issue-tracker-blue" /></a>


### PR DESCRIPTION
Run CI on pushes to main and add a badge reporting whether or not the CI
is passing to the README.

Not really related, but use the us ubuntu archive instead of the dk
(Denmark?) link on the suspicion that the us one would be more reliable.