### PR TITLE
Concepts link was not including end parenthesis

### DIFF
--- a/notebooks/tutorials/ops_tutorial.ipynb
+++ b/notebooks/tutorials/ops_tutorial.ipynb
@@ -11,7 +11,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "SymForce uses [concepts](https://en.wikipedia.org/wiki/Concept_(generic_programming)) as an underlying mechanism. A concept is a specification of supported operations, including syntax and semantics, but does not require a subtype relationship. This means that a set of heterogenous types can be operated on in a homogenous way, i.e. types that are external and don't share a base class, like Python floats treated as scalars.\n",
+    "SymForce uses [concepts](https://en.wikipedia.org/wiki/Concept_(generic_programming%29) as an underlying mechanism. A concept is a specification of supported operations, including syntax and semantics, but does not require a subtype relationship. This means that a set of heterogenous types can be operated on in a homogenous way, i.e. types that are external and don't share a base class, like Python floats treated as scalars.\n",
     "\n",
     "There are three core concepts, each of which is a superset of the previous. The core routines use these ops interfaces rather than calling methods on types directly. The [ops package](../api/symforce.ops.html) docs provide much more detail and each op is tested on each type, but examples are given here.\n",
     "\n",


### PR DESCRIPTION
Small change to use encoded character which appears to work. Sorry for the nit. It was misdirecting me to https://en.wikipedia.org/wiki/Concept_(generic_programming