### PR TITLE
Add docs as an artifact of CI runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,5 +108,5 @@ jobs:
       - name: Upload Generated Docs
         uses: actions/upload-artifact@v3
         with:
-          name: docs ${{ matrix }}
+          name: docs ${{ JSON.stringify(matrix) }}
           path: build/docs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,3 +104,9 @@ jobs:
           export PYTHONPATH=$PYTHONPATH:$(pwd)
           ${{ matrix.python }} test/symforce_requirements_test.py --update
           make -j2 test
+
+      - name: Upload Generated Docs
+        uses: actions/upload-artifact@v3
+        with:
+          name: docs
+          path: build/docs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,5 +108,5 @@ jobs:
       - name: Upload Generated Docs
         uses: actions/upload-artifact@v3
         with:
-          name: docs
+          name: docs ${{ matrix }}
           path: build/docs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,6 +105,10 @@ jobs:
           ${{ matrix.python }} test/symforce_requirements_test.py --update
           make -j2 test
 
+      # Upload the docs as an artifact
+      # To view, download the `docs` artifact from the build and matrix entry you're interested in
+      # (probably any is good, assuming they all pass)
+      # Unzip to a directory and run `npx http-server` in that directory
       - name: Upload Generated Docs
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,5 +108,5 @@ jobs:
       - name: Upload Generated Docs
         uses: actions/upload-artifact@v3
         with:
-          name: docs ${{ matrix.os }}-${{ matrix.python }}-${{ matrix.compiler }}
+          name: docs ${{ matrix.os }}-${{ matrix.python }}-${{ matrix.compiler.C }}
           path: build/docs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,5 +108,5 @@ jobs:
       - name: Upload Generated Docs
         uses: actions/upload-artifact@v3
         with:
-          name: docs ${{ JSON.stringify(matrix) }}
+          name: docs ${{ matrix.os }}-${{ matrix.python }}-${{ matrix.compiler }}
           path: build/docs


### PR DESCRIPTION
Add the docs generated by CI builds as artifacts that can be downloaded and viewed

See comment in workflow for usage