### PR TITLE
Fix warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,6 +69,10 @@ option(SYMFORCE_BUILD_STATIC_LIBRARIES
   OFF
 )
 
+set(SYMFORCE_COMPILE_OPTIONS -Wall;-Wextra;-Werror CACHE STRING
+  "Extra flags to pass to the compiler; defaults to enabling warnings"
+)
+
 set(SYMFORCE_PYTHON_OVERRIDE "" CACHE STRING
   "Python executable to use - if empty (the default), find python in the environment"
 )
@@ -266,6 +270,7 @@ add_library(
   ${SYMFORCE_GEN_SOURCES}
   ${SYMFORCE_GEN_HEADERS}
 )
+target_compile_options(symforce_gen PRIVATE ${SYMFORCE_COMPILE_OPTIONS})
 target_link_libraries(symforce_gen ${SYMFORCE_EIGEN_TARGET} symforce_lcmtypes_cpp)
 target_include_directories(
   symforce_gen

--- a/gen/cpp/sym/equirectangular_camera_cal.cc
+++ b/gen/cpp/sym/equirectangular_camera_cal.cc
@@ -143,6 +143,9 @@ Eigen::Matrix<Scalar, 3, 1> EquirectangularCameraCal<Scalar>::CameraRayFromPixel
     const Eigen::Matrix<Scalar, 2, 1>& pixel, const Scalar epsilon, Scalar* const is_valid) const {
   // Total ops: 19
 
+  // Unused inputs
+  (void)epsilon;
+
   // Input arrays
   const Eigen::Matrix<Scalar, 4, 1>& _self = Data();
 
@@ -176,6 +179,9 @@ Eigen::Matrix<Scalar, 3, 1> EquirectangularCameraCal<Scalar>::CameraRayFromPixel
     Eigen::Matrix<Scalar, 3, 4>* const point_D_cal,
     Eigen::Matrix<Scalar, 3, 2>* const point_D_pixel) const {
   // Total ops: 44
+
+  // Unused inputs
+  (void)epsilon;
 
   // Input arrays
   const Eigen::Matrix<Scalar, 4, 1>& _self = Data();

--- a/gen/cpp/sym/factors/between_factor_matrix31.h
+++ b/gen/cpp/sym/factors/between_factor_matrix31.h
@@ -39,6 +39,9 @@ void BetweenFactorMatrix31(const Eigen::Matrix<Scalar, 3, 1>& a,
                            Eigen::Matrix<Scalar, 6, 1>* const rhs = nullptr) {
   // Total ops: 102
 
+  // Unused inputs
+  (void)epsilon;
+
   // Input arrays
 
   // Intermediate terms (42)

--- a/gen/cpp/sym/factors/between_factor_pose3_position.h
+++ b/gen/cpp/sym/factors/between_factor_pose3_position.h
@@ -40,6 +40,9 @@ void BetweenFactorPose3Position(const sym::Pose3<Scalar>& a, const sym::Pose3<Sc
                                 Eigen::Matrix<Scalar, 12, 1>* const rhs = nullptr) {
   // Total ops: 553
 
+  // Unused inputs
+  (void)epsilon;
+
   // Input arrays
   const Eigen::Matrix<Scalar, 7, 1>& _a = a.Data();
   const Eigen::Matrix<Scalar, 7, 1>& _b = b.Data();

--- a/gen/cpp/sym/factors/prior_factor_matrix31.h
+++ b/gen/cpp/sym/factors/prior_factor_matrix31.h
@@ -37,6 +37,9 @@ void PriorFactorMatrix31(const Eigen::Matrix<Scalar, 3, 1>& value,
                          Eigen::Matrix<Scalar, 3, 1>* const rhs = nullptr) {
   // Total ops: 63
 
+  // Unused inputs
+  (void)epsilon;
+
   // Input arrays
 
   // Intermediate terms (6)

--- a/gen/cpp/sym/factors/prior_factor_pose3_position.h
+++ b/gen/cpp/sym/factors/prior_factor_pose3_position.h
@@ -39,6 +39,9 @@ void PriorFactorPose3Position(const sym::Pose3<Scalar>& value,
                               Eigen::Matrix<Scalar, 6, 1>* const rhs = nullptr) {
   // Total ops: 63
 
+  // Unused inputs
+  (void)epsilon;
+
   // Input arrays
   const Eigen::Matrix<Scalar, 7, 1>& _value = value.Data();
 

--- a/gen/cpp/sym/linear_camera_cal.cc
+++ b/gen/cpp/sym/linear_camera_cal.cc
@@ -134,6 +134,9 @@ Eigen::Matrix<Scalar, 3, 1> LinearCameraCal<Scalar>::CameraRayFromPixel(
     const Eigen::Matrix<Scalar, 2, 1>& pixel, const Scalar epsilon, Scalar* const is_valid) const {
   // Total ops: 4
 
+  // Unused inputs
+  (void)epsilon;
+
   // Input arrays
   const Eigen::Matrix<Scalar, 4, 1>& _self = Data();
 
@@ -161,6 +164,9 @@ Eigen::Matrix<Scalar, 3, 1> LinearCameraCal<Scalar>::CameraRayFromPixelWithJacob
     Eigen::Matrix<Scalar, 3, 4>* const point_D_cal,
     Eigen::Matrix<Scalar, 3, 2>* const point_D_pixel) const {
   // Total ops: 14
+
+  // Unused inputs
+  (void)epsilon;
 
   // Input arrays
   const Eigen::Matrix<Scalar, 4, 1>& _self = Data();

--- a/gen/cpp/sym/ops/atan_camera_cal/lie_group_ops.cc
+++ b/gen/cpp/sym/ops/atan_camera_cal/lie_group_ops.cc
@@ -17,6 +17,9 @@ sym::ATANCameraCal<Scalar> LieGroupOps<ATANCameraCal<Scalar>>::FromTangent(const
                                                                            const Scalar epsilon) {
   // Total ops: 0
 
+  // Unused inputs
+  (void)epsilon;
+
   // Input arrays
 
   // Intermediate terms (0)
@@ -39,6 +42,9 @@ LieGroupOps<ATANCameraCal<Scalar>>::ToTangent(const sym::ATANCameraCal<Scalar>& 
                                               const Scalar epsilon) {
   // Total ops: 0
 
+  // Unused inputs
+  (void)epsilon;
+
   // Input arrays
   const Eigen::Matrix<Scalar, 5, 1>& _a = a.Data();
 
@@ -60,6 +66,9 @@ template <typename Scalar>
 sym::ATANCameraCal<Scalar> LieGroupOps<ATANCameraCal<Scalar>>::Retract(
     const sym::ATANCameraCal<Scalar>& a, const TangentVec& vec, const Scalar epsilon) {
   // Total ops: 5
+
+  // Unused inputs
+  (void)epsilon;
 
   // Input arrays
   const Eigen::Matrix<Scalar, 5, 1>& _a = a.Data();
@@ -84,6 +93,9 @@ LieGroupOps<ATANCameraCal<Scalar>>::LocalCoordinates(const sym::ATANCameraCal<Sc
                                                      const sym::ATANCameraCal<Scalar>& b,
                                                      const Scalar epsilon) {
   // Total ops: 5
+
+  // Unused inputs
+  (void)epsilon;
 
   // Input arrays
   const Eigen::Matrix<Scalar, 5, 1>& _a = a.Data();

--- a/gen/cpp/sym/ops/double_sphere_camera_cal/lie_group_ops.cc
+++ b/gen/cpp/sym/ops/double_sphere_camera_cal/lie_group_ops.cc
@@ -17,6 +17,9 @@ sym::DoubleSphereCameraCal<Scalar> LieGroupOps<DoubleSphereCameraCal<Scalar>>::F
     const TangentVec& vec, const Scalar epsilon) {
   // Total ops: 0
 
+  // Unused inputs
+  (void)epsilon;
+
   // Input arrays
 
   // Intermediate terms (0)
@@ -40,6 +43,9 @@ LieGroupOps<DoubleSphereCameraCal<Scalar>>::ToTangent(const sym::DoubleSphereCam
                                                       const Scalar epsilon) {
   // Total ops: 0
 
+  // Unused inputs
+  (void)epsilon;
+
   // Input arrays
   const Eigen::Matrix<Scalar, 6, 1>& _a = a.Data();
 
@@ -62,6 +68,9 @@ template <typename Scalar>
 sym::DoubleSphereCameraCal<Scalar> LieGroupOps<DoubleSphereCameraCal<Scalar>>::Retract(
     const sym::DoubleSphereCameraCal<Scalar>& a, const TangentVec& vec, const Scalar epsilon) {
   // Total ops: 6
+
+  // Unused inputs
+  (void)epsilon;
 
   // Input arrays
   const Eigen::Matrix<Scalar, 6, 1>& _a = a.Data();
@@ -87,6 +96,9 @@ LieGroupOps<DoubleSphereCameraCal<Scalar>>::LocalCoordinates(
     const sym::DoubleSphereCameraCal<Scalar>& a, const sym::DoubleSphereCameraCal<Scalar>& b,
     const Scalar epsilon) {
   // Total ops: 6
+
+  // Unused inputs
+  (void)epsilon;
 
   // Input arrays
   const Eigen::Matrix<Scalar, 6, 1>& _a = a.Data();

--- a/gen/cpp/sym/ops/equirectangular_camera_cal/lie_group_ops.cc
+++ b/gen/cpp/sym/ops/equirectangular_camera_cal/lie_group_ops.cc
@@ -17,6 +17,9 @@ sym::EquirectangularCameraCal<Scalar> LieGroupOps<EquirectangularCameraCal<Scala
     const TangentVec& vec, const Scalar epsilon) {
   // Total ops: 0
 
+  // Unused inputs
+  (void)epsilon;
+
   // Input arrays
 
   // Intermediate terms (0)
@@ -38,6 +41,9 @@ LieGroupOps<EquirectangularCameraCal<Scalar>>::ToTangent(
     const sym::EquirectangularCameraCal<Scalar>& a, const Scalar epsilon) {
   // Total ops: 0
 
+  // Unused inputs
+  (void)epsilon;
+
   // Input arrays
   const Eigen::Matrix<Scalar, 4, 1>& _a = a.Data();
 
@@ -58,6 +64,9 @@ template <typename Scalar>
 sym::EquirectangularCameraCal<Scalar> LieGroupOps<EquirectangularCameraCal<Scalar>>::Retract(
     const sym::EquirectangularCameraCal<Scalar>& a, const TangentVec& vec, const Scalar epsilon) {
   // Total ops: 4
+
+  // Unused inputs
+  (void)epsilon;
 
   // Input arrays
   const Eigen::Matrix<Scalar, 4, 1>& _a = a.Data();
@@ -81,6 +90,9 @@ LieGroupOps<EquirectangularCameraCal<Scalar>>::LocalCoordinates(
     const sym::EquirectangularCameraCal<Scalar>& a, const sym::EquirectangularCameraCal<Scalar>& b,
     const Scalar epsilon) {
   // Total ops: 4
+
+  // Unused inputs
+  (void)epsilon;
 
   // Input arrays
   const Eigen::Matrix<Scalar, 4, 1>& _a = a.Data();

--- a/gen/cpp/sym/ops/linear_camera_cal/lie_group_ops.cc
+++ b/gen/cpp/sym/ops/linear_camera_cal/lie_group_ops.cc
@@ -17,6 +17,9 @@ sym::LinearCameraCal<Scalar> LieGroupOps<LinearCameraCal<Scalar>>::FromTangent(
     const TangentVec& vec, const Scalar epsilon) {
   // Total ops: 0
 
+  // Unused inputs
+  (void)epsilon;
+
   // Input arrays
 
   // Intermediate terms (0)
@@ -38,6 +41,9 @@ LieGroupOps<LinearCameraCal<Scalar>>::ToTangent(const sym::LinearCameraCal<Scala
                                                 const Scalar epsilon) {
   // Total ops: 0
 
+  // Unused inputs
+  (void)epsilon;
+
   // Input arrays
   const Eigen::Matrix<Scalar, 4, 1>& _a = a.Data();
 
@@ -58,6 +64,9 @@ template <typename Scalar>
 sym::LinearCameraCal<Scalar> LieGroupOps<LinearCameraCal<Scalar>>::Retract(
     const sym::LinearCameraCal<Scalar>& a, const TangentVec& vec, const Scalar epsilon) {
   // Total ops: 4
+
+  // Unused inputs
+  (void)epsilon;
 
   // Input arrays
   const Eigen::Matrix<Scalar, 4, 1>& _a = a.Data();
@@ -81,6 +90,9 @@ LieGroupOps<LinearCameraCal<Scalar>>::LocalCoordinates(const sym::LinearCameraCa
                                                        const sym::LinearCameraCal<Scalar>& b,
                                                        const Scalar epsilon) {
   // Total ops: 4
+
+  // Unused inputs
+  (void)epsilon;
 
   // Input arrays
   const Eigen::Matrix<Scalar, 4, 1>& _a = a.Data();

--- a/gen/cpp/sym/ops/matrix/lie_group_ops.h
+++ b/gen/cpp/sym/ops/matrix/lie_group_ops.h
@@ -36,15 +36,23 @@ struct LieGroupOps<Eigen::Matrix<ScalarType, Rows, Cols>>
 
   using TangentVec = Eigen::Matrix<Scalar, TangentDim(), 1>;
   static T FromTangent(const TangentVec& vec, const Scalar epsilon) {
+    (void)epsilon;  // unused
+
     return Eigen::Map<const T>(vec.data(), Rows, Cols);
   }
   static TangentVec ToTangent(const T& a, const Scalar epsilon) {
+    (void)epsilon;  // unused
+
     return Eigen::Map<const TangentVec>(a.data(), a.size());
   }
   static T Retract(const T& a, const TangentVec& vec, const Scalar epsilon) {
+    (void)epsilon;  // unused
+
     return a + Eigen::Map<const T>(vec.data(), a.rows(), a.cols());
   }
   static TangentVec LocalCoordinates(const T& a, const T& b, const Scalar epsilon) {
+    (void)epsilon;  // unused
+
     return (Eigen::Map<const TangentVec>(b.data(), b.size()) -
             Eigen::Map<const TangentVec>(a.data(), a.size()));
   }

--- a/gen/cpp/sym/ops/polynomial_camera_cal/lie_group_ops.cc
+++ b/gen/cpp/sym/ops/polynomial_camera_cal/lie_group_ops.cc
@@ -17,6 +17,9 @@ sym::PolynomialCameraCal<Scalar> LieGroupOps<PolynomialCameraCal<Scalar>>::FromT
     const TangentVec& vec, const Scalar epsilon) {
   // Total ops: 0
 
+  // Unused inputs
+  (void)epsilon;
+
   // Input arrays
 
   // Intermediate terms (0)
@@ -42,6 +45,9 @@ LieGroupOps<PolynomialCameraCal<Scalar>>::ToTangent(const sym::PolynomialCameraC
                                                     const Scalar epsilon) {
   // Total ops: 0
 
+  // Unused inputs
+  (void)epsilon;
+
   // Input arrays
   const Eigen::Matrix<Scalar, 8, 1>& _a = a.Data();
 
@@ -66,6 +72,9 @@ template <typename Scalar>
 sym::PolynomialCameraCal<Scalar> LieGroupOps<PolynomialCameraCal<Scalar>>::Retract(
     const sym::PolynomialCameraCal<Scalar>& a, const TangentVec& vec, const Scalar epsilon) {
   // Total ops: 8
+
+  // Unused inputs
+  (void)epsilon;
 
   // Input arrays
   const Eigen::Matrix<Scalar, 8, 1>& _a = a.Data();
@@ -93,6 +102,9 @@ LieGroupOps<PolynomialCameraCal<Scalar>>::LocalCoordinates(
     const sym::PolynomialCameraCal<Scalar>& a, const sym::PolynomialCameraCal<Scalar>& b,
     const Scalar epsilon) {
   // Total ops: 8
+
+  // Unused inputs
+  (void)epsilon;
 
   // Input arrays
   const Eigen::Matrix<Scalar, 8, 1>& _a = a.Data();

--- a/gen/cpp/sym/ops/pose2/lie_group_ops.cc
+++ b/gen/cpp/sym/ops/pose2/lie_group_ops.cc
@@ -17,6 +17,9 @@ sym::Pose2<Scalar> LieGroupOps<Pose2<Scalar>>::FromTangent(const TangentVec& vec
                                                            const Scalar epsilon) {
   // Total ops: 2
 
+  // Unused inputs
+  (void)epsilon;
+
   // Input arrays
 
   // Intermediate terms (0)
@@ -57,6 +60,9 @@ sym::Pose2<Scalar> LieGroupOps<Pose2<Scalar>>::Retract(const sym::Pose2<Scalar>&
                                                        const TangentVec& vec,
                                                        const Scalar epsilon) {
   // Total ops: 10
+
+  // Unused inputs
+  (void)epsilon;
 
   // Input arrays
   const Eigen::Matrix<Scalar, 4, 1>& _a = a.Data();

--- a/gen/cpp/sym/ops/rot2/lie_group_ops.cc
+++ b/gen/cpp/sym/ops/rot2/lie_group_ops.cc
@@ -17,6 +17,9 @@ sym::Rot2<Scalar> LieGroupOps<Rot2<Scalar>>::FromTangent(const TangentVec& vec,
                                                          const Scalar epsilon) {
   // Total ops: 2
 
+  // Unused inputs
+  (void)epsilon;
+
   // Input arrays
 
   // Intermediate terms (0)
@@ -52,6 +55,9 @@ template <typename Scalar>
 sym::Rot2<Scalar> LieGroupOps<Rot2<Scalar>>::Retract(const sym::Rot2<Scalar>& a,
                                                      const TangentVec& vec, const Scalar epsilon) {
   // Total ops: 8
+
+  // Unused inputs
+  (void)epsilon;
 
   // Input arrays
   const Eigen::Matrix<Scalar, 2, 1>& _a = a.Data();

--- a/gen/cpp/sym/ops/scalar/lie_group_ops.h
+++ b/gen/cpp/sym/ops/scalar/lie_group_ops.h
@@ -27,15 +27,23 @@ struct LieGroupOps : public internal::LieGroupOpsBase<T, T> {
   }
   using TangentVec = Eigen::Matrix<T, 1, 1>;
   static T FromTangent(const TangentVec& vec, const T epsilon) {
+    (void)epsilon;  // unused
+
     return vec[0];
   }
   static TangentVec ToTangent(const T& a, const T epsilon) {
+    (void)epsilon;  // unused
+
     return TangentVec::Constant(a);
   }
   static T Retract(const T& a, const TangentVec& vec, const T epsilon) {
+    (void)epsilon;  // unused
+
     return a + vec[0];
   }
   static TangentVec LocalCoordinates(const T& a, const T& b, const T epsilon) {
+    (void)epsilon;  // unused
+
     return TangentVec::Constant(b - a);
   }
 };

--- a/gen/cpp/sym/ops/spherical_camera_cal/lie_group_ops.cc
+++ b/gen/cpp/sym/ops/spherical_camera_cal/lie_group_ops.cc
@@ -17,6 +17,9 @@ sym::SphericalCameraCal<Scalar> LieGroupOps<SphericalCameraCal<Scalar>>::FromTan
     const TangentVec& vec, const Scalar epsilon) {
   // Total ops: 0
 
+  // Unused inputs
+  (void)epsilon;
+
   // Input arrays
 
   // Intermediate terms (0)
@@ -43,6 +46,9 @@ LieGroupOps<SphericalCameraCal<Scalar>>::ToTangent(const sym::SphericalCameraCal
                                                    const Scalar epsilon) {
   // Total ops: 0
 
+  // Unused inputs
+  (void)epsilon;
+
   // Input arrays
   const Eigen::Matrix<Scalar, 9, 1>& _a = a.Data();
 
@@ -68,6 +74,9 @@ template <typename Scalar>
 sym::SphericalCameraCal<Scalar> LieGroupOps<SphericalCameraCal<Scalar>>::Retract(
     const sym::SphericalCameraCal<Scalar>& a, const TangentVec& vec, const Scalar epsilon) {
   // Total ops: 9
+
+  // Unused inputs
+  (void)epsilon;
 
   // Input arrays
   const Eigen::Matrix<Scalar, 9, 1>& _a = a.Data();
@@ -96,6 +105,9 @@ LieGroupOps<SphericalCameraCal<Scalar>>::LocalCoordinates(const sym::SphericalCa
                                                           const sym::SphericalCameraCal<Scalar>& b,
                                                           const Scalar epsilon) {
   // Total ops: 9
+
+  // Unused inputs
+  (void)epsilon;
 
   // Input arrays
   const Eigen::Matrix<Scalar, 9, 1>& _a = a.Data();

--- a/symforce/codegen/backends/cpp/templates/geo_package/ops/matrix/lie_group_ops.h.jinja
+++ b/symforce/codegen/backends/cpp/templates/geo_package/ops/matrix/lie_group_ops.h.jinja
@@ -34,15 +34,23 @@ struct LieGroupOps<Eigen::Matrix<ScalarType, Rows, Cols>> : public internal::Lie
 
   using TangentVec = Eigen::Matrix<Scalar, TangentDim(), 1>;
   static T FromTangent(const TangentVec& vec, const Scalar epsilon) {
+    (void)epsilon; // unused
+
     return Eigen::Map<const T>(vec.data(), Rows, Cols);
   }
   static TangentVec ToTangent(const T& a, const Scalar epsilon) {
+    (void)epsilon; // unused
+
     return Eigen::Map<const TangentVec>(a.data(), a.size());
   }
   static T Retract(const T& a, const TangentVec& vec, const Scalar epsilon) {
+    (void)epsilon; // unused
+
     return a + Eigen::Map<const T>(vec.data(), a.rows(), a.cols());
   }
   static TangentVec LocalCoordinates(const T& a, const T& b, const Scalar epsilon) {
+    (void)epsilon; // unused
+
     return (Eigen::Map<const TangentVec>(b.data(), b.size()) -
             Eigen::Map<const TangentVec>(a.data(), a.size()));
   }

--- a/symforce/codegen/backends/cpp/templates/geo_package/ops/scalar/lie_group_ops.h.jinja
+++ b/symforce/codegen/backends/cpp/templates/geo_package/ops/scalar/lie_group_ops.h.jinja
@@ -27,15 +27,23 @@ struct LieGroupOps : public internal::LieGroupOpsBase<T, T> {
   }
   using TangentVec = Eigen::Matrix<T, 1, 1>;
   static T FromTangent(const TangentVec& vec, const T epsilon) {
+    (void)epsilon; // unused
+
     return vec[0];
   }
   static TangentVec ToTangent(const T& a, const T epsilon) {
+    (void)epsilon; // unused
+
     return TangentVec::Constant(a);
   }
   static T Retract(const T& a, const TangentVec& vec, const T epsilon) {
+    (void)epsilon; // unused
+
     return a + vec[0];
   }
   static TangentVec LocalCoordinates(const T& a, const T& b, const T epsilon) {
+    (void)epsilon; // unused
+
     return TangentVec::Constant(b - a);
   }
 };

--- a/symforce/codegen/backends/cpp/templates/tests/cam_function_codegen_cpp_test.cc.jinja
+++ b/symforce/codegen/backends/cpp/templates/tests/cam_function_codegen_cpp_test.cc.jinja
@@ -29,7 +29,6 @@ TEMPLATE_TEST_CASE("Test generated function", "[cam_function]", sym::LinearCamer
   using T = TestType;
   using Scalar = typename T::Scalar;
   Scalar epsilon = 1e-6; // For preventing degenerate numerical cases (e.g. division by zero)
-  Scalar tolerance = 10.0 * epsilon; // For assessing approximate equality
 
   Eigen::Matrix<Scalar, sym::StorageOps<T>::StorageDim(), 1> data;
   std::mt19937 gen(42);
@@ -39,8 +38,6 @@ TEMPLATE_TEST_CASE("Test generated function", "[cam_function]", sym::LinearCamer
   }
   T cam(data);
   spdlog::info("*** Testing generated function with {} ***", cam);
-
-  int is_valid;
 
   Eigen::Matrix<Scalar, 2, 1> pixel;
   pixel << 2.0 * cam_dist(gen), 2.0 * cam_dist(gen);

--- a/symforce/codegen/backends/cpp/templates/tests/cam_package_cpp_test.cc.jinja
+++ b/symforce/codegen/backends/cpp/templates/tests/cam_package_cpp_test.cc.jinja
@@ -137,7 +137,7 @@ TEMPLATE_TEST_CASE("Test storage ops", "[cam_package]", {{ ", ".join(cpp_cam_typ
 
   std::array<Scalar, storage_dim> arr;
   cam_cal.ToStorage(arr.data());
-  for (int i = 0; i < arr.size(); ++i) {
+  for (int i = 0; i < static_cast<int>(arr.size()); ++i) {
     CHECK(arr[i] == cam_cal.Data()[i]);
   }
 
@@ -223,7 +223,6 @@ TEMPLATE_TEST_CASE("Test Camera class", "[cam_package]", {{ ", ".join(fully_impl
 
   using Scalar = typename T::Scalar;
   const Scalar epsilon = 1e-6; // For preventing degenerate numerical cases (e.g. division by zero)
-  const Scalar tolerance = 10.0 * epsilon; // For checking approx. equality
 
   spdlog::info("*** Testing Camera class with calibration: {} ***", cam_cal);
 

--- a/symforce/codegen/backends/cpp/templates/tests/geo_package_cpp_test.cc.jinja
+++ b/symforce/codegen/backends/cpp/templates/tests/geo_package_cpp_test.cc.jinja
@@ -147,8 +147,8 @@ TEMPLATE_TEST_CASE("Test Storage ops", "[geo_package]", {{ ", ".join(cpp_geo_typ
   vec.resize(storage_dim);
   sym::StorageOps<T>::ToStorage(value, vec.data());
   CHECK(vec.size() > 0);
-  CHECK(vec.size() == storage_dim);
-  for (int i = 0; i < vec.size(); ++i) {
+  CHECK(static_cast<int>(vec.size()) == storage_dim);
+  for (int i = 0; i < static_cast<int>(vec.size()); ++i) {
     CHECK(vec[i] == value.Data()[i]);
   }
 
@@ -198,8 +198,8 @@ TEMPLATE_TEST_CASE("Test Matrix storage ops", "[geo_package]", {{ ", ".join(cpp_
   std::vector<Scalar> vec;
   vec.resize(storage_dim);
   sym::StorageOps<T>::ToStorage(value, vec.data());
-  CHECK(vec.size() == storage_dim);
-  for (int i = 0; i < vec.size(); ++i) {
+  CHECK(static_cast<int>(vec.size()) == storage_dim);
+  for (int i = 0; i < static_cast<int>(vec.size()); ++i) {
     CHECK(vec[i] == value[i]);
   }
 
@@ -428,7 +428,7 @@ TEMPLATE_TEST_CASE("Test Lie group ops", "[geo_package]", {{ ", ".join(cpp_geo_t
   // due to epsilon doesn't extend too far away from 0
   {
     TangentVec small_perturbation = TangentVec::Zero();
-    for (size_t i = 0; i < sym::LieGroupOps<T>::TangentDim(); i++) {
+    for (int i = 0; i < sym::LieGroupOps<T>::TangentDim(); i++) {
       small_perturbation(i) = std::sqrt(epsilon);
       const T value = sym::LieGroupOps<T>::FromTangent(small_perturbation, epsilon);
       const TangentVec recovered_perturbation = sym::LieGroupOps<T>::ToTangent(value, epsilon);

--- a/symforce/codegen/backends/cpp/templates/util/util.jinja
+++ b/symforce/codegen/backends/cpp/templates/util/util.jinja
@@ -400,10 +400,17 @@ _{{ lhs }} = {{ rhs }};
 {% macro expr_code(spec, scalar_type="Scalar") -%}
     // Total ops: {{ spec.total_ops() }}
 
+    {% if spec.unused_arguments %}
+    // Unused inputs
+    {% for arg in spec.unused_arguments %}
+    (void){{ arg }};
+    {% endfor %}
+
+    {% endif %}
     // Input arrays
     {% for name, type in spec.inputs.items() %}
         {% set T = typing_util.get_type(type) %}
-        {% if not issubclass(T, Values) and not issubclass(T, Matrix) and not is_symbolic(type) and not is_sequence(type) %}
+        {% if name not in spec.unused_arguments and not issubclass(T, Values) and not issubclass(T, Matrix) and not is_symbolic(type) and not is_sequence(type) %}
             {% if name == "self" %}
     const {{ vector_type(ops.StorageOps.storage_dim(type), scalar_type) }}& _{{ name }} = Data();
             {% else %}

--- a/symforce/examples/CMakeLists.txt
+++ b/symforce/examples/CMakeLists.txt
@@ -18,6 +18,7 @@ add_library(
   ${SYMFORCE_EXAMPLES_SOURCES}
   ${SYMFORCE_EXAMPLES_HEADERS}
 )
+target_compile_options(symforce_examples PRIVATE ${SYMFORCE_COMPILE_OPTIONS})
 target_link_libraries(
   symforce_examples
   symforce_gen

--- a/symforce/examples/bundle_adjustment_fixed_size/gen/cpp/symforce/bundle_adjustment_fixed_size/linearization.h
+++ b/symforce/examples/bundle_adjustment_fixed_size/gen/cpp/symforce/bundle_adjustment_fixed_size/linearization.h
@@ -148,13 +148,17 @@ void Linearization(
     Eigen::Matrix<Scalar, 26, 1>* const rhs = nullptr) {
   // Total ops: 10336
 
+  // Unused inputs
+  (void)priors_0_0_target_T_src;
+  (void)priors_0_0_sqrt_info;
+  (void)priors_1_1_target_T_src;
+  (void)priors_1_1_sqrt_info;
+
   // Input arrays
   const Eigen::Matrix<Scalar, 7, 1>& _views_0_pose = views_0_pose.Data();
   const Eigen::Matrix<Scalar, 7, 1>& _views_1_pose = views_1_pose.Data();
-  const Eigen::Matrix<Scalar, 7, 1>& _priors_0_0_target_T_src = priors_0_0_target_T_src.Data();
   const Eigen::Matrix<Scalar, 7, 1>& _priors_0_1_target_T_src = priors_0_1_target_T_src.Data();
   const Eigen::Matrix<Scalar, 7, 1>& _priors_1_0_target_T_src = priors_1_0_target_T_src.Data();
-  const Eigen::Matrix<Scalar, 7, 1>& _priors_1_1_target_T_src = priors_1_1_target_T_src.Data();
 
   // Intermediate terms (2287)
   const Scalar _tmp0 = 2 * _views_0_pose[2];

--- a/symforce/examples/example_utils/bundle_adjustment_util.h
+++ b/symforce/examples/example_utils/bundle_adjustment_util.h
@@ -12,6 +12,7 @@
 #include <sym/linear_camera_cal.h>
 #include <sym/posed_camera.h>
 #include <sym/util/typedefs.h>
+#include <symforce/opt/assert.h>
 
 namespace sym {
 namespace example_utils {
@@ -91,7 +92,7 @@ std::vector<Eigen::Matrix<Scalar, 2, 1>> PickSourceCoordsRandomlyFromGrid(
       SampleRegularGrid<Scalar>(image_shape, bucket_width_px);
 
   // Pick randomly the required number of source pixels
-  SYM_ASSERT(uv_samples.size() >= num_coords);
+  SYM_ASSERT(static_cast<int>(uv_samples.size()) >= num_coords);
   std::shuffle(uv_samples.begin(), uv_samples.end(), gen);
 
   std::vector<Eigen::Matrix<Scalar, 2, 1>> subset_uv_samples;

--- a/symforce/examples/robot_2d_localization/run_localization.cc
+++ b/symforce/examples/robot_2d_localization/run_localization.cc
@@ -63,8 +63,8 @@ void RunLocalization() {
   values.Set({'d', 1}, 1.4);
   const std::array<std::array<double, 3>, 3> angles = {
       {{55, 245, -35}, {95, 220, -20}, {125, 220, -20}}};
-  for (int i = 0; i < angles.size(); ++i) {
-    for (int j = 0; j < angles[0].size(); ++j) {
+  for (int i = 0; i < static_cast<int>(angles.size()); ++i) {
+    for (int j = 0; j < static_cast<int>(angles[0].size()); ++j) {
       values.Set({'a', i, j}, angles[i][j] * M_PI / 180);
     }
   }

--- a/symforce/opt/CMakeLists.txt
+++ b/symforce/opt/CMakeLists.txt
@@ -128,6 +128,7 @@ add_library(
   ${SYMFORCE_CHOLESKY_SOURCES}
   ${SYMFORCE_CHOLESKY_HEADERS}
 )
+target_compile_options(symforce_cholesky PRIVATE ${SYMFORCE_COMPILE_OPTIONS})
 target_link_libraries(symforce_cholesky metis ${SYMFORCE_EIGEN_TARGET})
 target_include_directories(symforce_cholesky PUBLIC ../..)
 
@@ -142,6 +143,7 @@ add_library(
   ${SYMFORCE_OPT_SOURCES}
   ${SYMFORCE_OPT_HEADERS}
 )
+target_compile_options(symforce_opt PRIVATE ${SYMFORCE_COMPILE_OPTIONS})
 target_link_libraries(symforce_opt
   symforce_gen
   symforce_cholesky

--- a/symforce/opt/gnc_optimizer.h
+++ b/symforce/opt/gnc_optimizer.h
@@ -75,7 +75,7 @@ class GncOptimizer : public BaseOptimizerType {
 
     // Iterate.
     BaseOptimizer::Optimize(values, num_iterations, populate_best_linearization, stats);
-    while (stats->iterations.size() < num_iterations) {
+    while (static_cast<int>(stats->iterations.size()) < num_iterations) {
       // NOTE(aaron): We shouldn't be here unless the optimization early exited (i.e. we had
       // iterations left)
       SYM_ASSERT(stats->early_exited);

--- a/symforce/opt/internal/hash_combine.h
+++ b/symforce/opt/internal/hash_combine.h
@@ -16,7 +16,7 @@ namespace internal {
  * Reference:
  *     https://stackoverflow.com/questions/2590677/how-do-i-combine-hash-values-in-c0x
  */
-inline void hash_combine(std::size_t& seed) {}
+inline void hash_combine(std::size_t& /* seed */) {}
 
 template <typename T, typename... Rest>
 inline void hash_combine(std::size_t& seed, const T& v, Rest... rest) {

--- a/symforce/opt/internal/linearizer_utils.h
+++ b/symforce/opt/internal/linearizer_utils.h
@@ -91,12 +91,10 @@ CoordsToStorageMap CoordsToStorageOffset(const Eigen::SparseMatrix<Scalar>& mat)
 }
 
 template <typename Scalar>
-void ComputeKeyHelperSparseColOffsets(
-    const typename Factor<Scalar>::LinearizedDenseFactor& linearized_factor,
-    const CoordsToStorageMap& jacobian_row_col_to_storage_offset,
-    const CoordsToStorageMap& hessian_row_col_to_storage_offset,
-    linearization_dense_factor_helper_t& factor_helper) {
-  for (int key_i = 0; key_i < factor_helper.key_helpers.size(); ++key_i) {
+void ComputeKeyHelperSparseColOffsets(const CoordsToStorageMap& jacobian_row_col_to_storage_offset,
+                                      const CoordsToStorageMap& hessian_row_col_to_storage_offset,
+                                      linearization_dense_factor_helper_t& factor_helper) {
+  for (int key_i = 0; key_i < static_cast<int>(factor_helper.key_helpers.size()); ++key_i) {
     linearization_dense_key_helper_t& key_helper = factor_helper.key_helpers[key_i];
 
     key_helper.jacobian_storage_col_starts.resize(key_helper.tangent_dim);
@@ -148,7 +146,7 @@ void ComputeKeyHelperSparseMap(
   // We're computing this in UpdateFromSparseOnesFactorIntoTripletLists too...
   std::vector<int> key_for_factor_offset;
   // Reserve?
-  for (int key_i = 0; key_i < factor_helper.key_helpers.size(); key_i++) {
+  for (int key_i = 0; key_i < static_cast<int>(factor_helper.key_helpers.size()); key_i++) {
     for (int key_offset = 0; key_offset < factor_helper.key_helpers[key_i].tangent_dim;
          key_offset++) {
       key_for_factor_offset.push_back(key_i);
@@ -204,7 +202,7 @@ FactorHelperT ComputeFactorHelper(const LinearizedFactorT& factor,
   factor_helper.residual_dim = factor.residual.rows();
   factor_helper.combined_residual_offset = combined_residual_offset;
 
-  for (int key_i = 0; key_i < factor.index.entries.size(); ++key_i) {
+  for (int key_i = 0; key_i < static_cast<int>(factor.index.entries.size()); ++key_i) {
     const index_entry_t& entry = factor.index.entries[key_i];
 
     const bool key_is_optimized = state_index.count(entry.key) > 0;

--- a/symforce/opt/linearizer.cc
+++ b/symforce/opt/linearizer.cc
@@ -182,14 +182,12 @@ void Linearizer<ScalarType>::InitializeStorageAndIndices() {
       internal::CoordsToStorageOffset(linearization_ones_.hessian_lower);
 
   // Use the hash map to mark sparse storage offsets for every row of each key block of each factor
-  for (int i = 0; i < dense_linearized_factors_.size(); ++i) {
-    const LinearizedDenseFactor& linearized_factor = dense_linearized_factors_[i];
+  for (int i = 0; i < static_cast<int>(dense_linearized_factors_.size()); ++i) {
     linearization_dense_factor_helper_t& factor_helper = dense_factor_update_helpers_[i];
     internal::ComputeKeyHelperSparseColOffsets<Scalar>(
-        linearized_factor, jacobian_row_col_to_storage_offset, hessian_row_col_to_storage_offset,
-        factor_helper);
+        jacobian_row_col_to_storage_offset, hessian_row_col_to_storage_offset, factor_helper);
   }
-  for (int i = 0; i < sparse_linearized_factors_.size(); ++i) {
+  for (int i = 0; i < static_cast<int>(sparse_linearized_factors_.size()); ++i) {
     const LinearizedSparseFactor& linearized_factor = sparse_linearized_factors_[i];
     linearization_sparse_factor_helper_t& factor_helper = sparse_factor_update_helpers_[i];
     internal::ComputeKeyHelperSparseMap<Scalar>(linearized_factor,
@@ -268,7 +266,7 @@ void Linearizer<ScalarType>::UpdateFromLinearizedDenseFactorIntoSparse(
                                   factor_helper.residual_dim) = linearized_factor.residual;
 
   // For each key
-  for (int key_i = 0; key_i < factor_helper.key_helpers.size(); ++key_i) {
+  for (int key_i = 0; key_i < static_cast<int>(factor_helper.key_helpers.size()); ++key_i) {
     const linearization_dense_key_helper_t& key_helper = factor_helper.key_helpers[key_i];
 
     // Fill in jacobian block, column by column
@@ -304,7 +302,7 @@ void Linearizer<ScalarType>::UpdateFromLinearizedDenseFactorIntoSparse(
       const std::vector<int32_t>& col_starts = key_helper.hessian_storage_col_starts[key_j];
 
       if (key_helper_j.combined_offset < key_helper.combined_offset) {
-        for (int32_t col_j = 0; col_j < col_starts.size(); ++col_j) {
+        for (int32_t col_j = 0; col_j < static_cast<int32_t>(col_starts.size()); ++col_j) {
           Eigen::Map<VectorX<Scalar>>(linearization->hessian_lower.valuePtr() + col_starts[col_j],
                                       key_helper.tangent_dim) +=
               linearized_factor.hessian.block(key_helper.factor_offset,
@@ -312,7 +310,7 @@ void Linearizer<ScalarType>::UpdateFromLinearizedDenseFactorIntoSparse(
                                               key_helper.tangent_dim, 1);
         }
       } else {
-        for (int32_t col_i = 0; col_i < col_starts.size(); ++col_i) {
+        for (int32_t col_i = 0; col_i < static_cast<int32_t>(col_starts.size()); ++col_i) {
           Eigen::Map<VectorX<Scalar>>(linearization->hessian_lower.valuePtr() + col_starts[col_i],
                                       key_helper_j.tangent_dim) +=
               linearized_factor.hessian
@@ -339,7 +337,7 @@ void Linearizer<ScalarType>::UpdateFromLinearizedSparseFactorIntoSparse(
                                   factor_helper.residual_dim) = linearized_factor.residual;
 
   // Add contribution from right-hand-side
-  for (int key_i = 0; key_i < factor_helper.key_helpers.size(); ++key_i) {
+  for (int key_i = 0; key_i < static_cast<int>(factor_helper.key_helpers.size()); ++key_i) {
     const linearization_sparse_key_helper_t& key_helper = factor_helper.key_helpers[key_i];
 
     linearization->rhs.segment(key_helper.combined_offset, key_helper.tangent_dim) +=
@@ -347,15 +345,17 @@ void Linearizer<ScalarType>::UpdateFromLinearizedSparseFactorIntoSparse(
   }
 
   // Fill out jacobian
-  SYM_ASSERT(factor_helper.jacobian_index_map.size() == linearized_factor.jacobian.nonZeros());
-  for (int i = 0; i < factor_helper.jacobian_index_map.size(); i++) {
+  SYM_ASSERT(factor_helper.jacobian_index_map.size() ==
+             static_cast<size_t>(linearized_factor.jacobian.nonZeros()));
+  for (int i = 0; i < static_cast<int>(factor_helper.jacobian_index_map.size()); i++) {
     linearization->jacobian.valuePtr()[factor_helper.jacobian_index_map[i]] =
         linearized_factor.jacobian.valuePtr()[i];
   }
 
   // Fill out hessian
-  SYM_ASSERT(factor_helper.hessian_index_map.size() == linearized_factor.hessian.nonZeros());
-  for (int i = 0; i < factor_helper.hessian_index_map.size(); i++) {
+  SYM_ASSERT(factor_helper.hessian_index_map.size() ==
+             static_cast<size_t>(linearized_factor.hessian.nonZeros()));
+  for (int i = 0; i < static_cast<int>(factor_helper.hessian_index_map.size()); i++) {
     linearization->hessian_lower.valuePtr()[factor_helper.hessian_index_map[i]] +=
         linearized_factor.hessian.valuePtr()[i];
   }
@@ -378,7 +378,7 @@ void Linearizer<ScalarType>::UpdatePatternFromDenseFactorIntoTripletLists(
       };
 
   // For each key
-  for (int key_i = 0; key_i < factor_helper.key_helpers.size(); ++key_i) {
+  for (int key_i = 0; key_i < static_cast<int>(factor_helper.key_helpers.size()); ++key_i) {
     const linearization_dense_key_helper_t& key_helper = factor_helper.key_helpers[key_i];
 
     // Fill in jacobian block
@@ -417,7 +417,7 @@ void Linearizer<ScalarType>::UpdatePatternFromSparseFactorIntoTripletLists(
     std::vector<Eigen::Triplet<Scalar>>* const hessian_lower_triplets) const {
   std::vector<int> key_for_factor_offset;
   // key_for_factor_offset.reserve();
-  for (int key_i = 0; key_i < factor_helper.key_helpers.size(); key_i++) {
+  for (int key_i = 0; key_i < static_cast<int>(factor_helper.key_helpers.size()); key_i++) {
     for (int key_offset = 0; key_offset < factor_helper.key_helpers[key_i].tangent_dim;
          key_offset++) {
       key_for_factor_offset.push_back(key_i);
@@ -502,11 +502,11 @@ void Linearizer<ScalarType>::BuildCombinedProblemSparse(
       .setZero();
 
   // Update each factor using precomputed index helpers
-  for (int i = 0; i < dense_linearized_factors.size(); ++i) {
+  for (int i = 0; i < static_cast<int>(dense_linearized_factors.size()); ++i) {
     UpdateFromLinearizedDenseFactorIntoSparse(dense_linearized_factors[i],
                                               dense_factor_update_helpers_[i], linearization);
   }
-  for (int i = 0; i < sparse_linearized_factors.size(); ++i) {
+  for (int i = 0; i < static_cast<int>(sparse_linearized_factors.size()); ++i) {
     UpdateFromLinearizedSparseFactorIntoSparse(sparse_linearized_factors[i],
                                                sparse_factor_update_helpers_[i], linearization);
   }
@@ -521,11 +521,11 @@ void Linearizer<ScalarType>::BuildCombinedProblemSparsityPattern(
   std::vector<Eigen::Triplet<Scalar>> hessian_lower_triplets;
 
   // Update each factor using precomputed index helpers
-  for (int i = 0; i < dense_factor_update_helpers_.size(); ++i) {
+  for (int i = 0; i < static_cast<int>(dense_factor_update_helpers_.size()); ++i) {
     UpdatePatternFromDenseFactorIntoTripletLists(dense_factor_update_helpers_[i],
                                                  &jacobian_triplets, &hessian_lower_triplets);
   }
-  for (int i = 0; i < sparse_linearized_factors_.size(); i++) {
+  for (int i = 0; i < static_cast<int>(sparse_linearized_factors_.size()); i++) {
     UpdatePatternFromSparseFactorIntoTripletLists(sparse_linearized_factors_[i],
                                                   sparse_factor_update_helpers_[i],
                                                   &jacobian_triplets, &hessian_lower_triplets);

--- a/symforce/opt/optimizer.h
+++ b/symforce/opt/optimizer.h
@@ -239,7 +239,7 @@ class Optimizer {
    * Call nonlinear_solver_.Iterate on the given values (updating in place) until out of iterations
    * or converged
    */
-  void IterateToConvergence(Values<Scalar>* values, size_t num_iterations,
+  void IterateToConvergence(Values<Scalar>* values, int num_iterations,
                             bool populate_best_linearization, OptimizationStats<Scalar>* stats);
 
   /**

--- a/symforce/opt/optimizer.tcc
+++ b/symforce/opt/optimizer.tcc
@@ -201,8 +201,8 @@ const optimizer_params_t& Optimizer<ScalarType, NonlinearSolverType>::Params() c
 
 template <typename ScalarType, typename NonlinearSolverType>
 void Optimizer<ScalarType, NonlinearSolverType>::IterateToConvergence(
-    Values<Scalar>* const values, const size_t num_iterations,
-    const bool populate_best_linearization, OptimizationStats<Scalar>* const stats) {
+    Values<Scalar>* const values, const int num_iterations, const bool populate_best_linearization,
+    OptimizationStats<Scalar>* const stats) {
   SYM_TIME_SCOPE("Optimizer<{}>::IterateToConvergence", name_);
   bool optimization_early_exited = false;
 

--- a/symforce/opt/util.h
+++ b/symforce/opt/util.h
@@ -20,7 +20,7 @@ namespace internal {
  */
 template <typename T>
 struct TangentDimHelper {
-  static int32_t TangentDim(const T& x) {
+  static int32_t TangentDim(const T& /* x */) {
     return sym::LieGroupOps<T>::TangentDim();
   }
 };
@@ -114,7 +114,7 @@ auto NumericalDerivative(const F f, const X& x,
 
   JacobianMat J = JacobianMat::Zero(internal::TangentDimHelper<Y>::TangentDim(f0),
                                     internal::TangentDimHelper<X>::TangentDim(x));
-  for (size_t i = 0; i < internal::TangentDimHelper<X>::TangentDim(x); i++) {
+  for (int i = 0; i < internal::TangentDimHelper<X>::TangentDim(x); i++) {
     dx(i) = delta;
     const typename sym::LieGroupOps<Y>::TangentVec y_plus = sym::LieGroupOps<Y>::LocalCoordinates(
         f0, f(sym::LieGroupOps<X>::Retract(x, dx, epsilon)), epsilon);

--- a/symforce/opt/values.cc
+++ b/symforce/opt/values.cc
@@ -200,7 +200,7 @@ template <typename Scalar>
 void Values<Scalar>::Update(const index_t& index_this, const index_t& index_other,
                             const Values<Scalar>& other) {
   SYM_ASSERT(index_this.entries.size() == index_other.entries.size());
-  for (int i = 0; i < index_this.entries.size(); ++i) {
+  for (int i = 0; i < static_cast<int>(index_this.entries.size()); ++i) {
     const index_entry_t& entry_this = index_this.entries[i];
     const index_entry_t& entry_other = index_other.entries[i];
     SYM_ASSERT(entry_this.storage_dim == entry_other.storage_dim);

--- a/symforce/opt/values.tcc
+++ b/symforce/opt/values.tcc
@@ -116,7 +116,7 @@ void Values<Scalar>::SetInternal(const index_entry_t& entry, const T& value) {
   static_assert(std::is_same<Scalar, typename StorageOps<T>::Scalar>::value,
                 "Calling Values.Set on mismatched scalar type.");
   SYM_ASSERT((entry.type == StorageOps<T>::TypeEnum()));
-  SYM_ASSERT((entry.offset + entry.storage_dim <= data_.size()));
+  SYM_ASSERT((entry.offset + entry.storage_dim <= static_cast<int>(data_.size())));
   StorageOps<T>::ToStorage(value, data_.data() + entry.offset);
 }
 

--- a/symforce/pybind/CMakeLists.txt
+++ b/symforce/pybind/CMakeLists.txt
@@ -32,6 +32,8 @@ pybind11_add_module(
   sym_type_casters.cc
 )
 
+target_compile_options(cc_sym PRIVATE ${SYMFORCE_COMPILE_OPTIONS})
+
 if(SYMFORCE_PY_EXTENSION_MODULE_OUTPUT_PATH)
   set_target_properties(cc_sym PROPERTIES
     LIBRARY_OUTPUT_DIRECTORY ${SYMFORCE_PY_EXTENSION_MODULE_OUTPUT_PATH}

--- a/symforce/pybind/cc_values.cc
+++ b/symforce/pybind/cc_values.cc
@@ -135,7 +135,7 @@ struct RegisterMatricesHelper<0, M> {
 
 template <>
 struct RegisterMatricesHelper<0, 1> {
-  static void Register(py::class_<sym::Valuesd> cls) {}
+  static void Register(py::class_<sym::Valuesd> /* cls */) {}
 };
 
 /**
@@ -222,7 +222,7 @@ void AddValuesWrapper(pybind11::module_ module) {
           "retract",
           [](sym::Valuesd& v, const sym::index_t& index, const std::vector<double>& delta,
              const double epsilon) {
-            if (index.tangent_dim != delta.size()) {
+            if (index.tangent_dim != static_cast<int>(delta.size())) {
               throw std::runtime_error(
                   fmt::format("The length of delta [{}] must match index.tangent_dim [{}]",
                               delta.size(), index.tangent_dim));

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -16,8 +16,13 @@ add_library(
   ${SYMFORCE_TEST_SOURCES}
   ${SYMFORCE_TEST_HEADERS}
 )
+target_compile_options(symforce_test PRIVATE ${SYMFORCE_COMPILE_OPTIONS})
 target_link_libraries(symforce_test Catch2::Catch2WithMain symforce_gen symforce_opt)
+
+# TODO(aaron): Marking these all as system, so we don't warn inside them.  Ideally we'd maybe warn
+# in generated code, just not LCM bindings?
 target_include_directories(symforce_test
+  SYSTEM
   INTERFACE symforce_function_codegen_test_data/symengine/cam_function_codegen_test_data/cpp
   INTERFACE symforce_function_codegen_test_data/symengine/codegen_multi_function_test_data/cpp
   INTERFACE symforce_function_codegen_test_data/symengine/codegen_nan_test_data/cpp

--- a/test/cam_function_codegen_cpp_test.cc
+++ b/test/cam_function_codegen_cpp_test.cc
@@ -30,7 +30,6 @@ TEMPLATE_TEST_CASE("Test generated function", "[cam_function]", sym::LinearCamer
   using T = TestType;
   using Scalar = typename T::Scalar;
   Scalar epsilon = 1e-6;  // For preventing degenerate numerical cases (e.g. division by zero)
-  Scalar tolerance = 10.0 * epsilon;  // For assessing approximate equality
 
   Eigen::Matrix<Scalar, sym::StorageOps<T>::StorageDim(), 1> data;
   std::mt19937 gen(42);
@@ -40,8 +39,6 @@ TEMPLATE_TEST_CASE("Test generated function", "[cam_function]", sym::LinearCamer
   }
   T cam(data);
   spdlog::info("*** Testing generated function with {} ***", cam);
-
-  int is_valid;
 
   Eigen::Matrix<Scalar, 2, 1> pixel;
   pixel << 2.0 * cam_dist(gen), 2.0 * cam_dist(gen);

--- a/test/cam_package_cpp_test.cc
+++ b/test/cam_package_cpp_test.cc
@@ -146,7 +146,7 @@ TEMPLATE_TEST_CASE("Test storage ops", "[cam_package]", sym::LinearCameraCal<dou
 
   std::array<Scalar, storage_dim> arr;
   cam_cal.ToStorage(arr.data());
-  for (int i = 0; i < arr.size(); ++i) {
+  for (int i = 0; i < static_cast<int>(arr.size()); ++i) {
     CHECK(arr[i] == cam_cal.Data()[i]);
   }
 
@@ -260,7 +260,6 @@ TEMPLATE_TEST_CASE("Test Camera class", "[cam_package]", sym::LinearCameraCal<do
 
   using Scalar = typename T::Scalar;
   const Scalar epsilon = 1e-6;  // For preventing degenerate numerical cases (e.g. division by zero)
-  const Scalar tolerance = 10.0 * epsilon;  // For checking approx. equality
 
   spdlog::info("*** Testing Camera class with calibration: {} ***", cam_cal);
 

--- a/test/geo_package_cpp_test.cc
+++ b/test/geo_package_cpp_test.cc
@@ -150,8 +150,8 @@ TEMPLATE_TEST_CASE("Test Storage ops", "[geo_package]", sym::Rot2<double>, sym::
   vec.resize(storage_dim);
   sym::StorageOps<T>::ToStorage(value, vec.data());
   CHECK(vec.size() > 0);
-  CHECK(vec.size() == storage_dim);
-  for (int i = 0; i < vec.size(); ++i) {
+  CHECK(static_cast<int>(vec.size()) == storage_dim);
+  for (int i = 0; i < static_cast<int>(vec.size()); ++i) {
     CHECK(vec[i] == value.Data()[i]);
   }
 
@@ -207,8 +207,8 @@ TEMPLATE_TEST_CASE("Test Matrix storage ops", "[geo_package]", sym::Vector1<doub
   std::vector<Scalar> vec;
   vec.resize(storage_dim);
   sym::StorageOps<T>::ToStorage(value, vec.data());
-  CHECK(vec.size() == storage_dim);
-  for (int i = 0; i < vec.size(); ++i) {
+  CHECK(static_cast<int>(vec.size()) == storage_dim);
+  for (int i = 0; i < static_cast<int>(vec.size()); ++i) {
     CHECK(vec[i] == value[i]);
   }
 
@@ -433,7 +433,7 @@ TEMPLATE_TEST_CASE("Test Lie group ops", "[geo_package]", sym::Rot2<double>, sym
   // due to epsilon doesn't extend too far away from 0
   {
     TangentVec small_perturbation = TangentVec::Zero();
-    for (size_t i = 0; i < sym::LieGroupOps<T>::TangentDim(); i++) {
+    for (int i = 0; i < sym::LieGroupOps<T>::TangentDim(); i++) {
       small_perturbation(i) = std::sqrt(epsilon);
       const T value = sym::LieGroupOps<T>::FromTangent(small_perturbation, epsilon);
       const TangentVec recovered_perturbation = sym::LieGroupOps<T>::ToTangent(value, epsilon);

--- a/test/symforce_examples_bundle_adjustment_fixed_size_test.cc
+++ b/test/symforce_examples_bundle_adjustment_fixed_size_test.cc
@@ -5,7 +5,7 @@
 
 #include <symforce/examples/bundle_adjustment_fixed_size/run_bundle_adjustment.h>
 
-int main(int argc, char** argv) {
+int main() {
   // This SYM_ASSERTs on failure instead of CHECK, since it isn't a test
   bundle_adjustment_fixed_size::RunBundleAdjustment();
 }

--- a/test/symforce_examples_bundle_adjustment_test.cc
+++ b/test/symforce_examples_bundle_adjustment_test.cc
@@ -5,7 +5,7 @@
 
 #include <symforce/examples/bundle_adjustment/run_bundle_adjustment.h>
 
-int main(int argc, char** argv) {
+int main() {
   // This SYM_ASSERTs on failure instead of CHECK, since it isn't a test
   bundle_adjustment::RunBundleAdjustment();
 }

--- a/test/symforce_examples_robot_2d_localization_test.cc
+++ b/test/symforce_examples_robot_2d_localization_test.cc
@@ -5,7 +5,7 @@
 
 #include <symforce/examples/robot_2d_localization/run_localization.h>
 
-int main(int argc, char** argv) {
+int main() {
   // This SYM_ASSERTs on failure instead of CHECK
   robot_2d_localization::RunLocalization();
 }

--- a/test/symforce_examples_robot_3d_localization_fixed_test.cc
+++ b/test/symforce_examples_robot_3d_localization_fixed_test.cc
@@ -5,7 +5,7 @@
 
 #include <symforce/examples/robot_3d_localization/run_fixed_size.h>
 
-int main(int argc, char** argv) {
+int main() {
   // This SYM_ASSERTs on failure instead of CHECK, since it isn't a test
   robot_3d_localization::RunFixed();
 }

--- a/test/symforce_examples_robot_3d_localization_test.cc
+++ b/test/symforce_examples_robot_3d_localization_test.cc
@@ -5,7 +5,7 @@
 
 #include <symforce/examples/robot_3d_localization/run_dynamic_size.h>
 
-int main(int argc, char** argv) {
+int main() {
   // This SYM_ASSERTs on failure instead of CHECK, since it isn't a test
   robot_3d_localization::RunDynamic();
 }

--- a/test/symforce_function_codegen_test_data/symengine/codegen_cpp_test_data/cpp/symforce/codegen_cpp_test/codegen_cpp_test.h
+++ b/test/symforce_function_codegen_test_data/symengine/codegen_cpp_test_data/cpp/symforce/codegen_cpp_test/codegen_cpp_test.h
@@ -54,6 +54,12 @@ void CodegenCppTest(
         nullptr) {
   // Total ops: 748
 
+  // Unused inputs
+  (void)rot_vec;
+  (void)list_of_lists;
+  (void)big_matrix;
+  (void)states;
+
   // Input arrays
   const Eigen::Matrix<Scalar, 4, 1>& _rot = rot.Data();
 

--- a/test/symforce_function_codegen_test_data/symengine/codegen_explicit_template_instantiation_test_data/cpp/symforce/codegen_explicit_template_instantiation_test/codegen_explicit_template_instantiation_test.h
+++ b/test/symforce_function_codegen_test_data/symengine/codegen_explicit_template_instantiation_test_data/cpp/symforce/codegen_explicit_template_instantiation_test/codegen_explicit_template_instantiation_test.h
@@ -58,6 +58,12 @@ void CodegenExplicitTemplateInstantiationTest(
         values_vec_2D_out = nullptr) {
   // Total ops: 748
 
+  // Unused inputs
+  (void)rot_vec;
+  (void)list_of_lists;
+  (void)big_matrix;
+  (void)states;
+
   // Input arrays
   const Eigen::Matrix<Scalar, 4, 1>& _rot = rot.Data();
 

--- a/test/symforce_function_codegen_test_data/symengine/databuffer_codegen_test_data/cpp/symforce/buffer_test/buffer_func.h
+++ b/test/symforce_function_codegen_test_data/symengine/databuffer_codegen_test_data/cpp/symforce/buffer_test/buffer_func.h
@@ -25,6 +25,9 @@ template <typename Scalar>
 Scalar BufferFunc(const Scalar* const buffer, const Scalar a, const Scalar b) {
   // Total ops: 8
 
+  // Unused inputs
+  (void)buffer;
+
   // Input arrays
 
   // Intermediate terms (1)

--- a/test/symforce_function_codegen_test_data/sympy/codegen_cpp_test_data/cpp/symforce/codegen_cpp_test/codegen_cpp_test.h
+++ b/test/symforce_function_codegen_test_data/sympy/codegen_cpp_test_data/cpp/symforce/codegen_cpp_test/codegen_cpp_test.h
@@ -54,6 +54,12 @@ void CodegenCppTest(
         nullptr) {
   // Total ops: 748
 
+  // Unused inputs
+  (void)rot_vec;
+  (void)list_of_lists;
+  (void)big_matrix;
+  (void)states;
+
   // Input arrays
   const Eigen::Matrix<Scalar, 4, 1>& _rot = rot.Data();
 

--- a/test/symforce_function_codegen_test_data/sympy/codegen_explicit_template_instantiation_test_data/cpp/symforce/codegen_explicit_template_instantiation_test/codegen_explicit_template_instantiation_test.h
+++ b/test/symforce_function_codegen_test_data/sympy/codegen_explicit_template_instantiation_test_data/cpp/symforce/codegen_explicit_template_instantiation_test/codegen_explicit_template_instantiation_test.h
@@ -58,6 +58,12 @@ void CodegenExplicitTemplateInstantiationTest(
         values_vec_2D_out = nullptr) {
   // Total ops: 748
 
+  // Unused inputs
+  (void)rot_vec;
+  (void)list_of_lists;
+  (void)big_matrix;
+  (void)states;
+
   // Input arrays
   const Eigen::Matrix<Scalar, 4, 1>& _rot = rot.Data();
 

--- a/test/symforce_function_codegen_test_data/sympy/databuffer_codegen_test_data/cpp/symforce/buffer_test/buffer_func.h
+++ b/test/symforce_function_codegen_test_data/sympy/databuffer_codegen_test_data/cpp/symforce/buffer_test/buffer_func.h
@@ -25,6 +25,9 @@ template <typename Scalar>
 Scalar BufferFunc(const Scalar* const buffer, const Scalar a, const Scalar b) {
   // Total ops: 9
 
+  // Unused inputs
+  (void)buffer;
+
   // Input arrays
 
   // Intermediate terms (0)

--- a/test/symforce_values_test.cc
+++ b/test/symforce_values_test.cc
@@ -27,7 +27,6 @@ TEMPLATE_TEST_CASE("Test values", "[values]", double, float) {
   using Scalar = TestType;
 
   spdlog::info("*** Testing Values<{}> ***", typeid(Scalar).name());
-  const Scalar epsilon = 1e-9;
 
   sym::Values<Scalar> v;
   CHECK(v.Keys().size() == 0);
@@ -90,13 +89,13 @@ TEMPLATE_TEST_CASE("Test values", "[values]", double, float) {
   // Right now since we removed a scalar the data array is one longer than the actual storage dim
   CHECK(v.NumEntries() == 7);
   const sym::index_t index_1 = v.CreateIndex(v.Keys());
-  CHECK(v.Data().size() == index_1.storage_dim + 1);
+  CHECK(static_cast<int>(v.Data().size()) == index_1.storage_dim + 1);
   CHECK(index_1.tangent_dim == index_1.storage_dim - 1);
 
   // Cleanup to get rid of the empty space from the scalar
-  size_t num_cleaned = v.Cleanup();
+  v.Cleanup();
   CHECK(v.NumEntries() == 7);
-  CHECK(v.Data().size() == index_1.storage_dim);
+  CHECK(static_cast<int>(v.Data().size()) == index_1.storage_dim);
   const sym::index_t index_2 = v.CreateIndex(v.Keys());
   CHECK(R1_new == v.template At<sym::Rot3<Scalar>>(R1_key));
   CHECK(Scalar(4.2) == v.template At<Scalar>({'f', 1}));

--- a/third_party/skymarshal/CMakeLists.txt
+++ b/third_party/skymarshal/CMakeLists.txt
@@ -2,5 +2,5 @@ cmake_minimum_required(VERSION 3.19)  # For interface library headers
 project(skymarshal)
 
 add_library(skymarshal_core INTERFACE include/lcm/lcm_coretypes.h)
-target_include_directories(skymarshal_core INTERFACE include)
+target_include_directories(skymarshal_core SYSTEM INTERFACE include)
 install(DIRECTORY include/ DESTINATION include)

--- a/third_party/skymarshal/cmake/skymarshal.cmake
+++ b/third_party/skymarshal/cmake/skymarshal.cmake
@@ -60,7 +60,8 @@ function(add_cpp_bindings
   endforeach()
 
   add_library(${target_name}_cpp INTERFACE ${generated_files})
-  target_include_directories(${target_name}_cpp INTERFACE ${bindings_dir}/cpp)
+  # TODO(aaron): Should these be system includes?  They do have warnings
+  target_include_directories(${target_name}_cpp SYSTEM INTERFACE ${bindings_dir}/cpp)
   target_link_libraries(${target_name}_cpp INTERFACE skymarshal_core)
 
   set(${generated_files_outvar} ${generated_files} PARENT_SCOPE)


### PR DESCRIPTION
Turn on -Wall, -Wextra, and -Werror, and fix all of them

Marking LCM C++ bindings, lcm_coretypes.h, generated test data (because
it contains LCM C++ bindings) as system includes so we don't fail the
build on warnings in them (which do exist).

The build should both now be warning-free (except for third-party
code), and fail if new warnings appear.

Reviewers: hayk-skydio,bradley-solliday-skydio,nathan-skydio
Topic: sym-warnings