### PR TITLE
Fix factor cache

### DIFF
--- a/symforce/opt/_internal/generated_residual_cache.py
+++ b/symforce/opt/_internal/generated_residual_cache.py
@@ -59,3 +59,9 @@ class GeneratedResidualCache:
         self._dict[
             _GRCKey(index=copy.deepcopy(index), optimized_keys=tuple(sorted(optimized_keys)))
         ] = residual
+
+    def __len__(self) -> int:
+        """
+        Returns the number of entries in the cache
+        """
+        return len(self._dict)

--- a/symforce/opt/factor.py
+++ b/symforce/opt/factor.py
@@ -233,8 +233,10 @@ class Factor:
         # If we have already generated a factor of the same form, load the previously generated
         # factor.
         similarity_index = SimilarityIndex.from_codegen(self.codegen)
+        codegen_keys = list(self.codegen.inputs.keys())
+        codegen_optimized_keys = [codegen_keys[self.keys.index(key)] for key in optimized_keys]
         cached_residual = Factor._generated_residual_cache.get_residual(
-            similarity_index, optimized_keys
+            similarity_index, codegen_optimized_keys
         )
         if cached_residual is not None:
             return NumericFactor(
@@ -256,7 +258,7 @@ class Factor:
         )
 
         Factor._generated_residual_cache.cache_residual(
-            similarity_index, optimized_keys, numeric_factor.linearization_function
+            similarity_index, codegen_optimized_keys, numeric_factor.linearization_function
         )
 
         if output_dir is None and logger.level != logging.DEBUG:

--- a/test/symforce_py_optimizer_test.py
+++ b/test/symforce_py_optimizer_test.py
@@ -89,6 +89,9 @@ class SymforcePyOptimizerTest(TestCase):
         )
         self.assertNotEqual(index_entry.key, key_t())
 
+        # Check that the factor cache has the expected number of entries
+        self.assertEqual(len(Factor._generated_residual_cache), 2)
+
         index_entry2 = optimizer.linearization_index_entry("x1")
         self.assertEqual(index_entry, index_entry2)
 


### PR DESCRIPTION
The optimized keys here need to be the keys to the factor `inputs`
Values, not to the problem.  At some point we refactored around this and
broke it.

Also add a unit test that goes fail->pass with this change

Reviewers: hayk,bradley,nathan
Topic: sym-grc-fix