### PR TITLE
Fix of pip install -e . on both macos and ubuntu

### DIFF
--- a/.github/workflows/test_editable_pip_install.yml
+++ b/.github/workflows/test_editable_pip_install.yml
@@ -1,0 +1,68 @@
+name: Test Editable Pip Install
+
+on:
+  push:
+    branches:
+      - 'main'
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  editable_install:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-20.04, macos-latest]
+        pip_version: [22.2.2]
+        setuptools_version: [65.3.0]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: install dev_requirements.txt
+        run: python3 -m pip install -r dev_requirements.txt
+
+      - name: Upgrade versions
+        run: |
+          python3 -m pip install pip==${{ matrix.pip_version }}
+          python3 -m pip install setuptools==${{ matrix.setuptools_version }}
+
+      - name: editable install
+        run: python3 -m pip install -e .
+
+      - name: Set expected install locations for ubuntu
+        if: ${{ matrix.os == 'ubuntu-20.04' }}
+        run: |
+          echo CC_SYM_LOCATION=/home/runner/work/symforce/symforce/cc_sym.cpython-38-x86_64-linux-gnu.so >> $GITHUB_ENV
+          echo SYM_LOCATION=/home/runner/.local/lib/python3.8/site-packages/sym/__init__.py >> $GITHUB_ENV
+          echo SKYMARSHAL_LOCATION=/home/runner/.local/lib/python3.8/site-packages/skymarshal/__init__.py >> $GITHUB_ENV
+          echo SYMENGINE_LOCATION=/home/runner/work/symforce/symforce/third_party/symenginepy/symengine/__init__.py >> $GITHUB_ENV
+          echo SF_SYMPY_LOCATION=/home/runner/work/symforce/symforce/third_party/symenginepy/symengine/__init__.py >> $GITHUB_ENV
+
+      - name: Set expected install locations for macos
+        if: ${{ matrix.os == 'macos-latest' }}
+        run: |
+          echo CC_SYM_LOCATION=/Users/runner/work/symforce/symforce/cc_sym.cpython-310-darwin.so >> $GITHUB_ENV
+          echo SYM_LOCATION=/usr/local/lib/python3.10/site-packages/sym/__init__.py >> $GITHUB_ENV
+          echo SKYMARSHAL_LOCATION=/usr/local/lib/python3.10/site-packages/skymarshal/__init__.py >> $GITHUB_ENV
+          echo SYMENGINE_LOCATION=/usr/local/lib/python3.10/site-packages/symengine/__init__.py >> $GITHUB_ENV
+          echo SF_SYMPY_LOCATION=/usr/local/lib/python3.10/site-packages/symengine/__init__.py >> $GITHUB_ENV
+
+      - name: Test cc_sym is installed in expected location
+        run: python3 -c "import cc_sym; assert cc_sym.__file__ == '$CC_SYM_LOCATION'"
+
+      - name: Test sym is installed in expected location
+        run: python3 -c "import sym; assert sym.__file__ == '$SYM_LOCATION'"
+
+      - name: Test skymarshal is installed in expected location
+        run: python3 -c "import skymarshal; assert skymarshal.__file__ == '$SKYMARSHAL_LOCATION'"
+
+      - name: Test symengine is installed in expected location
+        run: python3 -c "import symengine; assert symengine.__file__ == '$SYMENGINE_LOCATION'"
+
+      - name: Test symforce.symbolic.sympy returns a package from the expected location
+        run: python3 -c "import symforce.symbolic as sf; assert sf.sympy.__file__ == '$SF_SYMPY_LOCATION'"
+
+      - name: Check that symengine is default SymForce backend
+        run: python3 -c 'import symforce; assert(symforce.get_symbolic_api() == "symengine")'

--- a/symforce/pybind/lcm_type_casters.h
+++ b/symforce/pybind/lcm_type_casters.h
@@ -72,7 +72,7 @@ struct lcm_type_caster {
         py::module_::import(module_path.c_str()).attr(LCMType::getTypeName());
     py::object result = lcm_py_type.attr("decode")(msg_bytes);
     result.inc_ref();
-    return result;
+    return std::move(result);
   }
 };
 

--- a/symforce/pybind/sym_type_casters.h
+++ b/symforce/pybind/sym_type_casters.h
@@ -119,7 +119,7 @@ struct sym_type_caster {
         py::module_::import("sym").attr(handle_sym_type_name<T>::name.text).attr("from_storage");
     py::object result = from_storage(list);
     result.inc_ref();
-    return result;
+    return std::move(result);
   }
 };
 


### PR DESCRIPTION
This fixes the editable installation of symforce from source for setuptools>=64.0.0

This includes essentially two unrelated fixes.

The first is for `cc_sym`. The editable installation expects to find `cc_sym` in the top level of the symforce (I believe it's because setuptools finds the `cc_sym` shared library object in the top level of the source tree, which we have already been copying there from the build directory). However, the runpath of the `cc_sym` there still assumes the directory structure of the build directory that it was copied from. Hence, the loader can't find the dependencies (`libsymforce_gen`, `libsymforce_opt`, and `libsymforce_cholesky`).

To address this, I add the directory `cc_sym` is found in to its runpath (using `$ORIGIN` and `@loader_path`) and copy it's dependencies into it.

The second issue is that the editable installation expects the symengine package to use to be the one found in the source directory. However, that is missing the compiled `symengine_wrapper` shared library. To address this, I also copy it into the source directory.

For some reason the `symengine_wrapper` shared library file isn't always present in the `symengine_install` directory in the build directory (observed in on the github actions macos runner with python3.10), but it also seems to not always be needed. For that reason, if the copy fails, I tell the installation to just continue regardless.

Only performs these changes if `build_ext.editable_install` is `True`. Hence it requires `setuptools>=64.0.0` (the version in which setuptools was made pep 660 compliant).

Tested using a github actions workflow.