### PR TITLE
Upgrade setuptools to >= 64.0.0

### DIFF
--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -376,7 +376,7 @@ pip==22.1.2
     # via
     #   pip-tools
     #   symforce (setup.py)
-setuptools==62.3.2
+setuptools==65.3.0
     # via
     #   astroid
     #   ipython

--- a/setup.py
+++ b/setup.py
@@ -227,7 +227,7 @@ class InstallWithExtras(install):
 
 
 setup_requirements = [
-    "setuptools",
+    "setuptools>=64.0.0",
     "wheel",
     "pip",
     "cmake>=3.17",


### PR DESCRIPTION
setuptools was made pep 660 compliant in version 64.0.0. More generally, with this version it's not necessary to run `git clean -fdx` in order for `pip install .` to work, and editable installations will work (once PR 228 merges).