### PR TITLE
Use corrected runpaths w/ setup.py develop too

### DIFF
--- a/README.md
+++ b/README.md
@@ -565,9 +565,9 @@ pip install -e .
 
 This will build the C++ components of SymForce, but you won't be able to run `pip install -e .` repeatedly if you need to rebuild C++ code.  If you're changing C++ code and rebuilding, you should build with CMake directly as described <a href="#build-with-cmake">below</a>.
 
-If using the system python on a Debian system with a setuptools version before `64.0.0`, the editable install will not be placed in the correct location. Instead, either upgrade setuptools to a newer version or use a virtual environment.
-
 `pip install .` will not install pinned versions of SymForce's dependencies, it'll install any compatible versions.  It also won't install all packages required to run all of the SymForce tests and build all of the targets (e.g. building the docs or running the linters).  If you want all packages required for that, you should `pip install .[dev]` instead (or one of the other groups of extra requirements in our `setup.py`).  If you additionally want pinned versions of our dependencies, which are the exact versions guaranteed by CI to pass all of our tests, you can install them from `pip install -r dev_requirements.txt`.
+
+_Note: Editable installs as root with the system python on Ubuntu (and other Debian derivatives) are broken on `setuptools<64.0.0`.  This is a [bug in Debian](https://ffy00.github.io/blog/02-python-debian-and-the-install-locations/), not something in SymForce that we can fix.  If this is your situation, either use a virtual environment, upgrade setuptools to a version `>=64.0.0`, or use a different installation method._
 
 ## Build with CMake
 

--- a/README.md
+++ b/README.md
@@ -565,6 +565,8 @@ pip install -e .
 
 This will build the C++ components of SymForce, but you won't be able to run `pip install -e .` repeatedly if you need to rebuild C++ code.  If you're changing C++ code and rebuilding, you should build with CMake directly as described <a href="#build-with-cmake">below</a>.
 
+If using the system python on a Debian system with a setuptools version before `64.0.0`, the editable install will not be placed in the correct location. Instead, either upgrade setuptools to a newer version or use a virtual environment.
+
 `pip install .` will not install pinned versions of SymForce's dependencies, it'll install any compatible versions.  It also won't install all packages required to run all of the SymForce tests and build all of the targets (e.g. building the docs or running the linters).  If you want all packages required for that, you should `pip install .[dev]` instead (or one of the other groups of extra requirements in our `setup.py`).  If you additionally want pinned versions of our dependencies, which are the exact versions guaranteed by CI to pass all of our tests, you can install them from `pip install -r dev_requirements.txt`.
 
 ## Build with CMake

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ from setuptools import Extension
 from setuptools import find_packages
 from setuptools import setup
 from setuptools.command.build_ext import build_ext
+from setuptools.command.develop import develop
 from setuptools.command.egg_info import egg_info
 from setuptools.command.install import install
 
@@ -42,6 +43,30 @@ class CMakeExtension(Extension):
 
     def __init__(self, name: str):
         Extension.__init__(self, name, sources=[])
+
+
+class PatchDevelop(develop):
+    """
+    develop is the legacy command (pre setuptools==64.0.0, which implemented
+    the pep 660 hook build_editable) to build a package in editable mode.
+
+    This will be used by setuptools < 64.0.0, and not be used by
+    setuptools >= 64.0.0 during a normal `pip install -e .` run (of course,
+    you could still run `python setup.py develop` to run it with any version
+    of setuptools).
+    """
+
+    def run(self) -> None:  # type: ignore[override]
+        # NOTE(brad): In setuptools 64.0.0, the editable_mode field of the
+        # build_ext was added and is set to True during a pep 660 editable
+        # install.
+        # Since we want to use this field in our CMakeBuild extension of
+        # build_ext to identify if we're performing an editable install
+        # regardless of whether we're building with develop or build_editable,
+        # (both before and after version 64.0.0), we patch develop to add this
+        # field to build_ext and set it to True.
+        self.distribution.get_command_obj("build_ext").editable_mode = True  # type: ignore[attr-defined]
+        super().run()
 
 
 class CMakeBuild(build_ext):
@@ -310,7 +335,10 @@ docs_requirements = [
 ]
 
 cmdclass: T.Dict[str, T.Any] = dict(
-    build_ext=CMakeBuild, install=InstallWithExtras, egg_info=SymForceEggInfo
+    build_ext=CMakeBuild,
+    install=InstallWithExtras,
+    egg_info=SymForceEggInfo,
+    develop=PatchDevelop,
 )
 
 


### PR DESCRIPTION
This ensures that a previous fix which improved the installation of cc_sym and symengine when symforce was installed as an editable package using the new pep 660 build_editable hook is also applied when symforce is installed with `python setup.py develop`.

Most notably, this applies to all editable installations before setuptools==64.0.0.