### PR TITLE
Fix robot_2d_localization plotting

### DIFF
--- a/symforce/examples/robot_2d_localization/plotting.py
+++ b/symforce/examples/robot_2d_localization/plotting.py
@@ -160,7 +160,7 @@ def get_data_to_plot(v: Values) -> AttrDict:
     data.landmark_xy = np.array(v["landmarks"])
 
     # Pose positions
-    data.pose_xy = np.array([p.position() for p in v["poses"]])
+    data.pose_xy = np.array([p.position().squeeze() for p in v["poses"]])
 
     # Pose x/y axis vectors
     data.pose_x_axes = np.array([p.rotation() * np.array([1, 0]) for p in v["poses"]])

--- a/symforce/examples/robot_2d_localization/robot_2d_localization.py
+++ b/symforce/examples/robot_2d_localization/robot_2d_localization.py
@@ -11,6 +11,13 @@ and relative bearing angle measurements to known landmarks in the environment.
 # pylint: disable=ungrouped-imports
 
 # -----------------------------------------------------------------------------
+# Set the default epsilon to a symbol
+# -----------------------------------------------------------------------------
+import symforce
+
+symforce.set_epsilon_to_symbol()
+
+# -----------------------------------------------------------------------------
 # Define residual functions
 # -----------------------------------------------------------------------------
 import symforce.symbolic as sf

--- a/symforce/examples/robot_3d_localization/robot_3d_localization.py
+++ b/symforce/examples/robot_3d_localization/robot_3d_localization.py
@@ -13,9 +13,15 @@ to estimate the trajectory of the robot given known landmarks and noisy measurem
 # pylint: disable=ungrouped-imports
 
 # -----------------------------------------------------------------------------
-# Define residual functions
+# Set the default epsilon to a symbol
 # -----------------------------------------------------------------------------
 import symforce
+
+symforce.set_epsilon_to_symbol()
+
+# -----------------------------------------------------------------------------
+# Define residual functions
+# -----------------------------------------------------------------------------
 import symforce.symbolic as sf
 from symforce import logger
 from symforce import typing as T


### PR DESCRIPTION
Fixes #238

This was broken by the python matrix shape changes.  It'd be nice if we
had test coverage on this, although that does seem potentially
difficult.

Also added setting epsilon to a symbol, which silences a bunch of
warnings.  Not sure if this setup is ideal.
