### PR TITLE
Fix lcmtypes install during editable installation

### DIFF
--- a/.github/workflows/test_editable_pip_install.yml
+++ b/.github/workflows/test_editable_pip_install.yml
@@ -38,6 +38,8 @@ jobs:
           echo SYM_LOCATION=/home/runner/.local/lib/python3.8/site-packages/sym/__init__.py >> $GITHUB_ENV
           echo SKYMARSHAL_LOCATION=/home/runner/.local/lib/python3.8/site-packages/skymarshal/__init__.py >> $GITHUB_ENV
           echo SYMENGINE_LOCATION=/home/runner/work/${{ github.event.repository.name }}/${{ github.event.repository.name }}/third_party/symenginepy/symengine/__init__.py >> $GITHUB_ENV
+          echo LCMTYPES_SYM_LOCATION=/home/runner/work/${{ github.event.repository.name }}/${{ github.event.repository.name }}/lcmtypes_build/lcmtypes/sym/__init__.py >> $GITHUB_ENV
+          echo LCMTYPES_EIGENLCM_LOCATION=/home/runner/work/${{ github.event.repository.name }}/${{ github.event.repository.name }}/lcmtypes_build/lcmtypes/eigen_lcm/__init__.py >> $GITHUB_ENV
           echo SF_SYMPY_LOCATION=/home/runner/work/${{ github.event.repository.name }}/${{ github.event.repository.name }}/third_party/symenginepy/symengine/__init__.py >> $GITHUB_ENV
 
       - name: Set expected install locations for macos
@@ -47,6 +49,8 @@ jobs:
           echo SYM_LOCATION=/usr/local/lib/python3.10/site-packages/sym/__init__.py >> $GITHUB_ENV
           echo SKYMARSHAL_LOCATION=/usr/local/lib/python3.10/site-packages/skymarshal/__init__.py >> $GITHUB_ENV
           echo SYMENGINE_LOCATION=/usr/local/lib/python3.10/site-packages/symengine/__init__.py >> $GITHUB_ENV
+          echo LCMTYPES_SYM_LOCATION=/Users/runner/work/${{ github.event.repository.name }}/${{ github.event.repository.name }}/lcmtypes_build/lcmtypes/sym/__init__.py >> $GITHUB_ENV
+          echo LCMTYPES_EIGENLCM_LOCATION=/Users/runner/work/${{ github.event.repository.name }}/${{ github.event.repository.name }}/lcmtypes_build/lcmtypes/eigen_lcm/__init__.py >> $GITHUB_ENV
           echo SF_SYMPY_LOCATION=/usr/local/lib/python3.10/site-packages/symengine/__init__.py >> $GITHUB_ENV
 
       - name: Test cc_sym is installed in expected location
@@ -60,6 +64,12 @@ jobs:
 
       - name: Test symengine is installed in expected location
         run: python3 -c "import symengine; assert symengine.__file__ == '$SYMENGINE_LOCATION', symengine.__file__"
+
+      - name: Test lcmtypes.sym is installed in the expected location
+        run: python3 -c "import lcmtypes.sym; assert lcmtypes.sym.__file__ == '$LCMTYPES_SYM_LOCATION', lcmtypes.sym.__file__"
+
+      - name: Test lcmtypes.eigen_lcm is installed in the expected location
+        run: python3 -c "import lcmtypes.eigen_lcm; assert lcmtypes.eigen_lcm.__file__ == '$LCMTYPES_EIGENLCM_LOCATION', lcmtypes.eigen_lcm.__file__"
 
       - name: Test symforce.symbolic.sympy returns a package from the expected location
         run: python3 -c "import symforce.symbolic as sf; assert sf.sympy.__file__ == '$SF_SYMPY_LOCATION', sf.sympy.__file__"

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ dist/
 downloads/
 eggs/
 .eggs/
+lcmtypes_build/
 lib/
 lib64/
 parts/


### PR DESCRIPTION
Previously, `lcmtypes` package was installed by the `InstallWithExtras` (subclass of `setuptools.install`) command. However, this command is not run during an editable installation.

Because the lcmtypes package does not exist in the source directory, and is instead generated into the build directory by the `CMakeBuild` command (subclass of `setuptools.build_ext`), I've told `setuptools` to treat the `lcmtypes` package as an extension module.

This ensures setuptools does not attempt to install `lcmtypes` until the `build_ext` command has been run.

Note: if you treat it as an ordinary package, problems arise from the fact that the package isn't available until after the build step.

During a non-editable install, nothing particularly special needs to be done (other than being careful with the fact that we're dealing with a folder rather than a shared object file).

During an editable install, extension modules are placed in the source directory. Since the name of the package (`lcmtypes`) collides with the name of a directory in the top level of the source directory (the one containing the `.lcm` files that say how to generate the `lcmtypes` directory), I decided to make a point of placing the package in a different directory called `lcmtypes_build`. I don't think this is required for anything to work, but it seems less messy to me this way. In order to accomadate this, I told setuptools to look for the lcmtypes package in the `lcmtypes_build` directory by ammending the package_dir argument of `setup()`.

To test, I added checks to the `test_editable_pip_install` github actions workflow.

Note: We currently don't test non-editable pip installations. This is just because we haven't gotten around to it yet.

Fixes #239