### PR TITLE
Always raise IndexError if wrong shape genned code

### DIFF
--- a/gen/python/sym/ops/atan_camera_cal/camera_ops.py
+++ b/gen/python/sym/ops/atan_camera_cal/camera_ops.py
@@ -72,8 +72,14 @@ class CameraOps(object):
 
         # Input arrays
         _self = self.data
-        if len(point.shape) == 1:
+        if point.shape == (3,):
             point = point.reshape((3, 1))
+        elif point.shape != (3, 1):
+            raise IndexError(
+                "point is expected to have shape (3, 1) or (3,); instead had shape {}".format(
+                    point.shape
+                )
+            )
 
         # Intermediate terms (4)
         _tmp0 = max(epsilon, point[2, 0])
@@ -105,8 +111,14 @@ class CameraOps(object):
 
         # Input arrays
         _self = self.data
-        if len(point.shape) == 1:
+        if point.shape == (3,):
             point = point.reshape((3, 1))
+        elif point.shape != (3, 1):
+            raise IndexError(
+                "point is expected to have shape (3, 1) or (3,); instead had shape {}".format(
+                    point.shape
+                )
+            )
 
         # Intermediate terms (46)
         _tmp0 = 0.5 * _self[4]
@@ -200,8 +212,14 @@ class CameraOps(object):
 
         # Input arrays
         _self = self.data
-        if len(pixel.shape) == 1:
+        if pixel.shape == (2,):
             pixel = pixel.reshape((2, 1))
+        elif pixel.shape != (2, 1):
+            raise IndexError(
+                "pixel is expected to have shape (2, 1) or (2,); instead had shape {}".format(
+                    pixel.shape
+                )
+            )
 
         # Intermediate terms (5)
         _tmp0 = -_self[2] + pixel[0, 0]
@@ -242,8 +260,14 @@ class CameraOps(object):
 
         # Input arrays
         _self = self.data
-        if len(pixel.shape) == 1:
+        if pixel.shape == (2,):
             pixel = pixel.reshape((2, 1))
+        elif pixel.shape != (2, 1):
+            raise IndexError(
+                "pixel is expected to have shape (2, 1) or (2,); instead had shape {}".format(
+                    pixel.shape
+                )
+            )
 
         # Intermediate terms (54)
         _tmp0 = -_self[2] + pixel[0, 0]

--- a/gen/python/sym/ops/atan_camera_cal/lie_group_ops.py
+++ b/gen/python/sym/ops/atan_camera_cal/lie_group_ops.py
@@ -24,8 +24,14 @@ class LieGroupOps(object):
         # Total ops: 0
 
         # Input arrays
-        if len(vec.shape) == 1:
+        if vec.shape == (5,):
             vec = vec.reshape((5, 1))
+        elif vec.shape != (5, 1):
+            raise IndexError(
+                "vec is expected to have shape (5, 1) or (5,); instead had shape {}".format(
+                    vec.shape
+                )
+            )
 
         # Intermediate terms (0)
 
@@ -66,8 +72,14 @@ class LieGroupOps(object):
 
         # Input arrays
         _a = a.data
-        if len(vec.shape) == 1:
+        if vec.shape == (5,):
             vec = vec.reshape((5, 1))
+        elif vec.shape != (5, 1):
+            raise IndexError(
+                "vec is expected to have shape (5, 1) or (5,); instead had shape {}".format(
+                    vec.shape
+                )
+            )
 
         # Intermediate terms (0)
 

--- a/gen/python/sym/ops/double_sphere_camera_cal/camera_ops.py
+++ b/gen/python/sym/ops/double_sphere_camera_cal/camera_ops.py
@@ -72,8 +72,14 @@ class CameraOps(object):
 
         # Input arrays
         _self = self.data
-        if len(point.shape) == 1:
+        if point.shape == (3,):
             point = point.reshape((3, 1))
+        elif point.shape != (3, 1):
+            raise IndexError(
+                "point is expected to have shape (3, 1) or (3,); instead had shape {}".format(
+                    point.shape
+                )
+            )
 
         # Intermediate terms (13)
         _tmp0 = epsilon ** 2 + point[0, 0] ** 2 + point[1, 0] ** 2
@@ -158,8 +164,14 @@ class CameraOps(object):
 
         # Input arrays
         _self = self.data
-        if len(point.shape) == 1:
+        if point.shape == (3,):
             point = point.reshape((3, 1))
+        elif point.shape != (3, 1):
+            raise IndexError(
+                "point is expected to have shape (3, 1) or (3,); instead had shape {}".format(
+                    point.shape
+                )
+            )
 
         # Intermediate terms (40)
         _tmp0 = epsilon ** 2 + point[0, 0] ** 2 + point[1, 0] ** 2
@@ -287,8 +299,14 @@ class CameraOps(object):
 
         # Input arrays
         _self = self.data
-        if len(pixel.shape) == 1:
+        if pixel.shape == (2,):
             pixel = pixel.reshape((2, 1))
+        elif pixel.shape != (2, 1):
+            raise IndexError(
+                "pixel is expected to have shape (2, 1) or (2,); instead had shape {}".format(
+                    pixel.shape
+                )
+            )
 
         # Intermediate terms (12)
         _tmp0 = -_self[2] + pixel[0, 0]
@@ -334,8 +352,14 @@ class CameraOps(object):
 
         # Input arrays
         _self = self.data
-        if len(pixel.shape) == 1:
+        if pixel.shape == (2,):
             pixel = pixel.reshape((2, 1))
+        elif pixel.shape != (2, 1):
+            raise IndexError(
+                "pixel is expected to have shape (2, 1) or (2,); instead had shape {}".format(
+                    pixel.shape
+                )
+            )
 
         # Intermediate terms (111)
         _tmp0 = -_self[2] + pixel[0, 0]

--- a/gen/python/sym/ops/double_sphere_camera_cal/lie_group_ops.py
+++ b/gen/python/sym/ops/double_sphere_camera_cal/lie_group_ops.py
@@ -24,8 +24,14 @@ class LieGroupOps(object):
         # Total ops: 0
 
         # Input arrays
-        if len(vec.shape) == 1:
+        if vec.shape == (6,):
             vec = vec.reshape((6, 1))
+        elif vec.shape != (6, 1):
+            raise IndexError(
+                "vec is expected to have shape (6, 1) or (6,); instead had shape {}".format(
+                    vec.shape
+                )
+            )
 
         # Intermediate terms (0)
 
@@ -68,8 +74,14 @@ class LieGroupOps(object):
 
         # Input arrays
         _a = a.data
-        if len(vec.shape) == 1:
+        if vec.shape == (6,):
             vec = vec.reshape((6, 1))
+        elif vec.shape != (6, 1):
+            raise IndexError(
+                "vec is expected to have shape (6, 1) or (6,); instead had shape {}".format(
+                    vec.shape
+                )
+            )
 
         # Intermediate terms (0)
 

--- a/gen/python/sym/ops/equirectangular_camera_cal/camera_ops.py
+++ b/gen/python/sym/ops/equirectangular_camera_cal/camera_ops.py
@@ -72,8 +72,14 @@ class CameraOps(object):
 
         # Input arrays
         _self = self.data
-        if len(point.shape) == 1:
+        if point.shape == (3,):
             point = point.reshape((3, 1))
+        elif point.shape != (3, 1):
+            raise IndexError(
+                "point is expected to have shape (3, 1) or (3,); instead had shape {}".format(
+                    point.shape
+                )
+            )
 
         # Intermediate terms (1)
         _tmp0 = point[0, 0] ** 2 + point[2, 0] ** 2
@@ -113,8 +119,14 @@ class CameraOps(object):
 
         # Input arrays
         _self = self.data
-        if len(point.shape) == 1:
+        if point.shape == (3,):
             point = point.reshape((3, 1))
+        elif point.shape != (3, 1):
+            raise IndexError(
+                "point is expected to have shape (3, 1) or (3,); instead had shape {}".format(
+                    point.shape
+                )
+            )
 
         # Intermediate terms (10)
         _tmp0 = (
@@ -171,8 +183,14 @@ class CameraOps(object):
 
         # Input arrays
         _self = self.data
-        if len(pixel.shape) == 1:
+        if pixel.shape == (2,):
             pixel = pixel.reshape((2, 1))
+        elif pixel.shape != (2, 1):
+            raise IndexError(
+                "pixel is expected to have shape (2, 1) or (2,); instead had shape {}".format(
+                    pixel.shape
+                )
+            )
 
         # Intermediate terms (3)
         _tmp0 = (-_self[3] + pixel[1, 0]) / _self[1]
@@ -214,8 +232,14 @@ class CameraOps(object):
 
         # Input arrays
         _self = self.data
-        if len(pixel.shape) == 1:
+        if pixel.shape == (2,):
             pixel = pixel.reshape((2, 1))
+        elif pixel.shape != (2, 1):
+            raise IndexError(
+                "pixel is expected to have shape (2, 1) or (2,); instead had shape {}".format(
+                    pixel.shape
+                )
+            )
 
         # Intermediate terms (21)
         _tmp0 = -_self[3] + pixel[1, 0]

--- a/gen/python/sym/ops/equirectangular_camera_cal/lie_group_ops.py
+++ b/gen/python/sym/ops/equirectangular_camera_cal/lie_group_ops.py
@@ -24,8 +24,14 @@ class LieGroupOps(object):
         # Total ops: 0
 
         # Input arrays
-        if len(vec.shape) == 1:
+        if vec.shape == (4,):
             vec = vec.reshape((4, 1))
+        elif vec.shape != (4, 1):
+            raise IndexError(
+                "vec is expected to have shape (4, 1) or (4,); instead had shape {}".format(
+                    vec.shape
+                )
+            )
 
         # Intermediate terms (0)
 
@@ -64,8 +70,14 @@ class LieGroupOps(object):
 
         # Input arrays
         _a = a.data
-        if len(vec.shape) == 1:
+        if vec.shape == (4,):
             vec = vec.reshape((4, 1))
+        elif vec.shape != (4, 1):
+            raise IndexError(
+                "vec is expected to have shape (4, 1) or (4,); instead had shape {}".format(
+                    vec.shape
+                )
+            )
 
         # Intermediate terms (0)
 

--- a/gen/python/sym/ops/linear_camera_cal/camera_ops.py
+++ b/gen/python/sym/ops/linear_camera_cal/camera_ops.py
@@ -72,8 +72,14 @@ class CameraOps(object):
 
         # Input arrays
         _self = self.data
-        if len(point.shape) == 1:
+        if point.shape == (3,):
             point = point.reshape((3, 1))
+        elif point.shape != (3, 1):
+            raise IndexError(
+                "point is expected to have shape (3, 1) or (3,); instead had shape {}".format(
+                    point.shape
+                )
+            )
 
         # Intermediate terms (1)
         _tmp0 = 1 / max(epsilon, point[2, 0])
@@ -102,8 +108,14 @@ class CameraOps(object):
 
         # Input arrays
         _self = self.data
-        if len(point.shape) == 1:
+        if point.shape == (3,):
             point = point.reshape((3, 1))
+        elif point.shape != (3, 1):
+            raise IndexError(
+                "point is expected to have shape (3, 1) or (3,); instead had shape {}".format(
+                    point.shape
+                )
+            )
 
         # Intermediate terms (5)
         _tmp0 = max(epsilon, point[2, 0])
@@ -159,8 +171,14 @@ class CameraOps(object):
 
         # Input arrays
         _self = self.data
-        if len(pixel.shape) == 1:
+        if pixel.shape == (2,):
             pixel = pixel.reshape((2, 1))
+        elif pixel.shape != (2, 1):
+            raise IndexError(
+                "pixel is expected to have shape (2, 1) or (2,); instead had shape {}".format(
+                    pixel.shape
+                )
+            )
 
         # Intermediate terms (0)
 
@@ -189,8 +207,14 @@ class CameraOps(object):
 
         # Input arrays
         _self = self.data
-        if len(pixel.shape) == 1:
+        if pixel.shape == (2,):
             pixel = pixel.reshape((2, 1))
+        elif pixel.shape != (2, 1):
+            raise IndexError(
+                "pixel is expected to have shape (2, 1) or (2,); instead had shape {}".format(
+                    pixel.shape
+                )
+            )
 
         # Intermediate terms (4)
         _tmp0 = -_self[2] + pixel[0, 0]

--- a/gen/python/sym/ops/linear_camera_cal/lie_group_ops.py
+++ b/gen/python/sym/ops/linear_camera_cal/lie_group_ops.py
@@ -24,8 +24,14 @@ class LieGroupOps(object):
         # Total ops: 0
 
         # Input arrays
-        if len(vec.shape) == 1:
+        if vec.shape == (4,):
             vec = vec.reshape((4, 1))
+        elif vec.shape != (4, 1):
+            raise IndexError(
+                "vec is expected to have shape (4, 1) or (4,); instead had shape {}".format(
+                    vec.shape
+                )
+            )
 
         # Intermediate terms (0)
 
@@ -64,8 +70,14 @@ class LieGroupOps(object):
 
         # Input arrays
         _a = a.data
-        if len(vec.shape) == 1:
+        if vec.shape == (4,):
             vec = vec.reshape((4, 1))
+        elif vec.shape != (4, 1):
+            raise IndexError(
+                "vec is expected to have shape (4, 1) or (4,); instead had shape {}".format(
+                    vec.shape
+                )
+            )
 
         # Intermediate terms (0)
 

--- a/gen/python/sym/ops/polynomial_camera_cal/camera_ops.py
+++ b/gen/python/sym/ops/polynomial_camera_cal/camera_ops.py
@@ -72,8 +72,14 @@ class CameraOps(object):
 
         # Input arrays
         _self = self.data
-        if len(point.shape) == 1:
+        if point.shape == (3,):
             point = point.reshape((3, 1))
+        elif point.shape != (3, 1):
+            raise IndexError(
+                "point is expected to have shape (3, 1) or (3,); instead had shape {}".format(
+                    point.shape
+                )
+            )
 
         # Intermediate terms (4)
         _tmp0 = max(epsilon, point[2, 0])
@@ -117,8 +123,14 @@ class CameraOps(object):
 
         # Input arrays
         _self = self.data
-        if len(point.shape) == 1:
+        if point.shape == (3,):
             point = point.reshape((3, 1))
+        elif point.shape != (3, 1):
+            raise IndexError(
+                "point is expected to have shape (3, 1) or (3,); instead had shape {}".format(
+                    point.shape
+                )
+            )
 
         # Intermediate terms (35)
         _tmp0 = point[1, 0] ** 2

--- a/gen/python/sym/ops/polynomial_camera_cal/lie_group_ops.py
+++ b/gen/python/sym/ops/polynomial_camera_cal/lie_group_ops.py
@@ -24,8 +24,14 @@ class LieGroupOps(object):
         # Total ops: 0
 
         # Input arrays
-        if len(vec.shape) == 1:
+        if vec.shape == (8,):
             vec = vec.reshape((8, 1))
+        elif vec.shape != (8, 1):
+            raise IndexError(
+                "vec is expected to have shape (8, 1) or (8,); instead had shape {}".format(
+                    vec.shape
+                )
+            )
 
         # Intermediate terms (0)
 
@@ -72,8 +78,14 @@ class LieGroupOps(object):
 
         # Input arrays
         _a = a.data
-        if len(vec.shape) == 1:
+        if vec.shape == (8,):
             vec = vec.reshape((8, 1))
+        elif vec.shape != (8, 1):
+            raise IndexError(
+                "vec is expected to have shape (8, 1) or (8,); instead had shape {}".format(
+                    vec.shape
+                )
+            )
 
         # Intermediate terms (0)
 

--- a/gen/python/sym/ops/pose2/lie_group_ops.py
+++ b/gen/python/sym/ops/pose2/lie_group_ops.py
@@ -24,8 +24,14 @@ class LieGroupOps(object):
         # Total ops: 2
 
         # Input arrays
-        if len(vec.shape) == 1:
+        if vec.shape == (3,):
             vec = vec.reshape((3, 1))
+        elif vec.shape != (3, 1):
+            raise IndexError(
+                "vec is expected to have shape (3, 1) or (3,); instead had shape {}".format(
+                    vec.shape
+                )
+            )
 
         # Intermediate terms (0)
 
@@ -65,8 +71,14 @@ class LieGroupOps(object):
 
         # Input arrays
         _a = a.data
-        if len(vec.shape) == 1:
+        if vec.shape == (3,):
             vec = vec.reshape((3, 1))
+        elif vec.shape != (3, 1):
+            raise IndexError(
+                "vec is expected to have shape (3, 1) or (3,); instead had shape {}".format(
+                    vec.shape
+                )
+            )
 
         # Intermediate terms (2)
         _tmp0 = math.sin(vec[0, 0])

--- a/gen/python/sym/ops/pose3/lie_group_ops.py
+++ b/gen/python/sym/ops/pose3/lie_group_ops.py
@@ -24,8 +24,14 @@ class LieGroupOps(object):
         # Total ops: 15
 
         # Input arrays
-        if len(vec.shape) == 1:
+        if vec.shape == (6,):
             vec = vec.reshape((6, 1))
+        elif vec.shape != (6, 1):
+            raise IndexError(
+                "vec is expected to have shape (6, 1) or (6,); instead had shape {}".format(
+                    vec.shape
+                )
+            )
 
         # Intermediate terms (3)
         _tmp0 = math.sqrt(epsilon ** 2 + vec[0, 0] ** 2 + vec[1, 0] ** 2 + vec[2, 0] ** 2)
@@ -79,8 +85,14 @@ class LieGroupOps(object):
 
         # Input arrays
         _a = a.data
-        if len(vec.shape) == 1:
+        if vec.shape == (6,):
             vec = vec.reshape((6, 1))
+        elif vec.shape != (6, 1):
+            raise IndexError(
+                "vec is expected to have shape (6, 1) or (6,); instead had shape {}".format(
+                    vec.shape
+                )
+            )
 
         # Intermediate terms (8)
         _tmp0 = math.sqrt(epsilon ** 2 + vec[0, 0] ** 2 + vec[1, 0] ** 2 + vec[2, 0] ** 2)

--- a/gen/python/sym/ops/rot2/lie_group_ops.py
+++ b/gen/python/sym/ops/rot2/lie_group_ops.py
@@ -24,8 +24,14 @@ class LieGroupOps(object):
         # Total ops: 2
 
         # Input arrays
-        if len(vec.shape) == 1:
+        if vec.shape == (1,):
             vec = vec.reshape((1, 1))
+        elif vec.shape != (1, 1):
+            raise IndexError(
+                "vec is expected to have shape (1, 1) or (1,); instead had shape {}".format(
+                    vec.shape
+                )
+            )
 
         # Intermediate terms (0)
 
@@ -61,8 +67,14 @@ class LieGroupOps(object):
 
         # Input arrays
         _a = a.data
-        if len(vec.shape) == 1:
+        if vec.shape == (1,):
             vec = vec.reshape((1, 1))
+        elif vec.shape != (1, 1):
+            raise IndexError(
+                "vec is expected to have shape (1, 1) or (1,); instead had shape {}".format(
+                    vec.shape
+                )
+            )
 
         # Intermediate terms (2)
         _tmp0 = math.sin(vec[0, 0])

--- a/gen/python/sym/ops/rot3/lie_group_ops.py
+++ b/gen/python/sym/ops/rot3/lie_group_ops.py
@@ -24,8 +24,14 @@ class LieGroupOps(object):
         # Total ops: 15
 
         # Input arrays
-        if len(vec.shape) == 1:
+        if vec.shape == (3,):
             vec = vec.reshape((3, 1))
+        elif vec.shape != (3, 1):
+            raise IndexError(
+                "vec is expected to have shape (3, 1) or (3,); instead had shape {}".format(
+                    vec.shape
+                )
+            )
 
         # Intermediate terms (3)
         _tmp0 = math.sqrt(epsilon ** 2 + vec[0, 0] ** 2 + vec[1, 0] ** 2 + vec[2, 0] ** 2)
@@ -73,8 +79,14 @@ class LieGroupOps(object):
 
         # Input arrays
         _a = a.data
-        if len(vec.shape) == 1:
+        if vec.shape == (3,):
             vec = vec.reshape((3, 1))
+        elif vec.shape != (3, 1):
+            raise IndexError(
+                "vec is expected to have shape (3, 1) or (3,); instead had shape {}".format(
+                    vec.shape
+                )
+            )
 
         # Intermediate terms (8)
         _tmp0 = math.sqrt(epsilon ** 2 + vec[0, 0] ** 2 + vec[1, 0] ** 2 + vec[2, 0] ** 2)

--- a/gen/python/sym/ops/spherical_camera_cal/camera_ops.py
+++ b/gen/python/sym/ops/spherical_camera_cal/camera_ops.py
@@ -72,8 +72,14 @@ class CameraOps(object):
 
         # Input arrays
         _self = self.data
-        if len(point.shape) == 1:
+        if point.shape == (3,):
             point = point.reshape((3, 1))
+        elif point.shape != (3, 1):
+            raise IndexError(
+                "point is expected to have shape (3, 1) or (3,); instead had shape {}".format(
+                    point.shape
+                )
+            )
 
         # Intermediate terms (4)
         _tmp0 = math.sqrt(epsilon + point[0, 0] ** 2 + point[1, 0] ** 2)
@@ -111,8 +117,14 @@ class CameraOps(object):
 
         # Input arrays
         _self = self.data
-        if len(point.shape) == 1:
+        if point.shape == (3,):
             point = point.reshape((3, 1))
+        elif point.shape != (3, 1):
+            raise IndexError(
+                "point is expected to have shape (3, 1) or (3,); instead had shape {}".format(
+                    point.shape
+                )
+            )
 
         # Intermediate terms (40)
         _tmp0 = -epsilon

--- a/gen/python/sym/ops/spherical_camera_cal/lie_group_ops.py
+++ b/gen/python/sym/ops/spherical_camera_cal/lie_group_ops.py
@@ -24,8 +24,14 @@ class LieGroupOps(object):
         # Total ops: 0
 
         # Input arrays
-        if len(vec.shape) == 1:
+        if vec.shape == (9,):
             vec = vec.reshape((9, 1))
+        elif vec.shape != (9, 1):
+            raise IndexError(
+                "vec is expected to have shape (9, 1) or (9,); instead had shape {}".format(
+                    vec.shape
+                )
+            )
 
         # Intermediate terms (0)
 
@@ -74,8 +80,14 @@ class LieGroupOps(object):
 
         # Input arrays
         _a = a.data
-        if len(vec.shape) == 1:
+        if vec.shape == (9,):
             vec = vec.reshape((9, 1))
+        elif vec.shape != (9, 1):
+            raise IndexError(
+                "vec is expected to have shape (9, 1) or (9,); instead had shape {}".format(
+                    vec.shape
+                )
+            )
 
         # Intermediate terms (0)
 

--- a/gen/python/sym/pose2.py
+++ b/gen/python/sym/pose2.py
@@ -143,8 +143,14 @@ class Pose2(object):
 
         # Input arrays
         _self = self.data
-        if len(right.shape) == 1:
+        if right.shape == (2,):
             right = right.reshape((2, 1))
+        elif right.shape != (2, 1):
+            raise IndexError(
+                "right is expected to have shape (2, 1) or (2,); instead had shape {}".format(
+                    right.shape
+                )
+            )
 
         # Intermediate terms (0)
 
@@ -172,8 +178,14 @@ class Pose2(object):
 
         # Input arrays
         _self = self.data
-        if len(point.shape) == 1:
+        if point.shape == (2,):
             point = point.reshape((2, 1))
+        elif point.shape != (2, 1):
+            raise IndexError(
+                "point is expected to have shape (2, 1) or (2,); instead had shape {}".format(
+                    point.shape
+                )
+            )
 
         # Intermediate terms (0)
 

--- a/gen/python/sym/pose3.py
+++ b/gen/python/sym/pose3.py
@@ -140,8 +140,14 @@ class Pose3(object):
 
         # Input arrays
         _self = self.data
-        if len(right.shape) == 1:
+        if right.shape == (3,):
             right = right.reshape((3, 1))
+        elif right.shape != (3, 1):
+            raise IndexError(
+                "right is expected to have shape (3, 1) or (3,); instead had shape {}".format(
+                    right.shape
+                )
+            )
 
         # Intermediate terms (11)
         _tmp0 = 2 * _self[2]
@@ -196,8 +202,14 @@ class Pose3(object):
 
         # Input arrays
         _self = self.data
-        if len(point.shape) == 1:
+        if point.shape == (3,):
             point = point.reshape((3, 1))
+        elif point.shape != (3, 1):
+            raise IndexError(
+                "point is expected to have shape (3, 1) or (3,); instead had shape {}".format(
+                    point.shape
+                )
+            )
 
         # Intermediate terms (20)
         _tmp0 = 2 * _self[2]

--- a/gen/python/sym/rot2.py
+++ b/gen/python/sym/rot2.py
@@ -65,8 +65,14 @@ class Rot2(object):
 
         # Input arrays
         _self = self.data
-        if len(right.shape) == 1:
+        if right.shape == (2,):
             right = right.reshape((2, 1))
+        elif right.shape != (2, 1):
+            raise IndexError(
+                "right is expected to have shape (2, 1) or (2,); instead had shape {}".format(
+                    right.shape
+                )
+            )
 
         # Intermediate terms (0)
 

--- a/gen/python/sym/rot3.py
+++ b/gen/python/sym/rot3.py
@@ -88,8 +88,14 @@ class Rot3(object):
 
         # Input arrays
         _self = self.data
-        if len(right.shape) == 1:
+        if right.shape == (3,):
             right = right.reshape((3, 1))
+        elif right.shape != (3, 1):
+            raise IndexError(
+                "right is expected to have shape (3, 1) or (3,); instead had shape {}".format(
+                    right.shape
+                )
+            )
 
         # Intermediate terms (11)
         _tmp0 = 2 * _self[0]

--- a/symforce/codegen/backends/python/templates/util/util.jinja
+++ b/symforce/codegen/backends/python/templates/util/util.jinja
@@ -120,6 +120,45 @@ def {{ function_name_and_args(spec) }}:
 
 {# ------------------------------------------------------------------------- #}
 
+{# Helper for expr_code. Checks that an input matrix called name has a valid shape,
+ # raises an IndexError if invalid, and reshapes to be a 2d ndarray.
+ #
+ # If use_numba=True, the IndexError message raised does not say what the size of the
+ # argument passed in was. This is because numba compatible code must have any error
+ # messages known at compile time. Similarly, the reshaping is always performed
+ # because numba compatible code cannot reshape an array in a conditional.
+ #
+ # Prints nothing if shape is not of the form (1, N) or (N, 1). This is because
+ # only row and column vectors might also be reasonably represented with (N,).
+ #
+ # Args:
+ #     name (str): The name of the array to be checked and resized. Should be a user
+ #       argument name, as it is used in the error message.
+ #     shape (T.Tuple[int, int]): The expected shape of name.
+ #     use_numba (bool): Whether the generated code should be numba compatible.
+ #}
+{% macro check_size_and_reshape(name, shape, use_numba) %}
+{% if 1 in shape %}
+    {% if use_numba %}
+    {# NOTE(brad): Numba will complain if we reshape name inside of a conditional #}
+if not ({{ name }}.shape == {{ shape }} or {{ name }}.shape == ({{ shape | max }},)):
+    raise IndexError("{{ name }} is expected to have shape {{ shape }} or ({{ shape | max }},)")
+{{ name }} = {{ name }}.reshape({{ shape }})
+    {% else %}
+if {{ name }}.shape == ({{ shape | max }},):
+    {{ name }} = {{ name }}.reshape({{ shape }})
+elif {{ name }}.shape != {{ shape }}:
+    raise IndexError(
+        "{{ name }} is expected to have shape {{ shape }} or ({{ shape | max }},); instead had shape {}".format(
+            {{ name }}.shape
+        )
+    )
+    {% endif %}
+{% endif %}
+{% endmacro %}
+
+{# ------------------------------------------------------------------------- #}
+
 {# Generate inner code for computing the given expression.
  #
  # Args:
@@ -134,16 +173,8 @@ def {{ function_name_and_args(spec) }}:
     {% for name, type in spec.inputs.items() %}
         {% set T = typing_util.get_type(type) %}
         {% if issubclass(T, Matrix) %}
-            {% if spec.config.reshape_vectors and (T.SHAPE[0] == 1 or T.SHAPE[1] == 1) %}
-                {% if spec.config.use_numba %}
-                {# NOTE(brad): Numba will complain if we reshape name inside of a conditional #}
-    if not ({{ name }}.shape == {{ T.SHAPE }} or {{ name }}.shape == ({{ T.SHAPE | max }},)):
-        raise IndexError("{{ name }} is expected to have shape {{ T.SHAPE }} or ({{ T.SHAPE | max }},)")
-    {{ name }} = {{ name }}.reshape({{ T.SHAPE }})
-                {% else %}
-    if len({{ name }}.shape) == 1:
-        {{ name }} = {{ name }}.reshape({{ T.SHAPE }})
-                {% endif %}
+            {% if spec.config.reshape_vectors %}
+    {{ check_size_and_reshape(name, T.SHAPE, spec.config.use_numba) | indent }}
             {% endif %}
         {% elif not issubclass(T, Values) and not is_symbolic(type) and not is_sequence(type) %}
     _{{ name }} = {{ name }}.data

--- a/test/symforce_codegen_test.py
+++ b/test/symforce_codegen_test.py
@@ -318,6 +318,38 @@ class SymforceCodegenTest(TestCase):
 
         # ---------------------------------------------------------------------
 
+        row_shape = (1, 5)
+        col_shape = (4, 1)
+        mat_shape = (2, 2)
+
+        for use_numba in [False, True]:
+            reshape_vectors = True
+            with self.subTest(
+                msg="If reshape_vectors=True, row vectors which are too large raise IndexErrors"
+                + f" [{use_numba=}]"
+            ):
+                assert_config_works(
+                    use_numba, reshape_vectors, row_shape, col_shape, mat_shape, IndexError
+                )
+
+        # ---------------------------------------------------------------------
+
+        row_shape = (1, 4)
+        col_shape = (5, 1)
+        mat_shape = (2, 2)
+
+        for use_numba in [False, True]:
+            reshape_vectors = True
+            with self.subTest(
+                msg="If reshape_vectors=True, column vectors which are too large raise IndexErrors"
+                + f" [{use_numba=}]"
+            ):
+                assert_config_works(
+                    use_numba, reshape_vectors, row_shape, col_shape, mat_shape, IndexError
+                )
+
+        # ---------------------------------------------------------------------
+
         row_shape = (1, 4)
         col_shape = (4, 1)
         mat_shape = (4,)

--- a/test/symforce_function_codegen_test_data/symengine/az_el_from_point.py
+++ b/test/symforce_function_codegen_test_data/symengine/az_el_from_point.py
@@ -33,8 +33,14 @@ def az_el_from_point(nav_T_cam, nav_t_point, epsilon):
 
     # Input arrays
     _nav_T_cam = nav_T_cam.data
-    if len(nav_t_point.shape) == 1:
+    if nav_t_point.shape == (3,):
         nav_t_point = nav_t_point.reshape((3, 1))
+    elif nav_t_point.shape != (3, 1):
+        raise IndexError(
+            "nav_t_point is expected to have shape (3, 1) or (3,); instead had shape {}".format(
+                nav_t_point.shape
+            )
+        )
 
     # Intermediate terms (23)
     _tmp0 = 2 * _nav_T_cam[0]

--- a/test/symforce_function_codegen_test_data/sympy/az_el_from_point.py
+++ b/test/symforce_function_codegen_test_data/sympy/az_el_from_point.py
@@ -33,8 +33,14 @@ def az_el_from_point(nav_T_cam, nav_t_point, epsilon):
 
     # Input arrays
     _nav_T_cam = nav_T_cam.data
-    if len(nav_t_point.shape) == 1:
+    if nav_t_point.shape == (3,):
         nav_t_point = nav_t_point.reshape((3, 1))
+    elif nav_t_point.shape != (3, 1):
+        raise IndexError(
+            "nav_t_point is expected to have shape (3, 1) or (3,); instead had shape {}".format(
+                nav_t_point.shape
+            )
+        )
 
     # Intermediate terms (23)
     _tmp0 = 2 * _nav_T_cam[3]


### PR DESCRIPTION
Currently, if the `reshape_vectors` field of the `PythonConfig` is `True` and `use_numba` is `False`, the only way an `IndexError` will be raised from generated code is if an out of bounds index is used on one of the inputs.

Consequently, this means that if you pass in a vector which is large enough (say, a row vector where a column vector is needed, but only the first entry of the column vector is needed), the code will silently work.

This is probably not what the user would want, and is inconsistent with what we do when `use_numba=True` (where we check that the input shape is exactly something allowed).

So, I've changed the generated code `use_numba=False` code to be more analagous to the `use_numba=True` code.

Other notes:
- I also moved the jinja code for checking the array size and reshaping if appropriate to a seperate macro (`check_size_and_reshape`). This was purely for readability.
- In the unit test I added, I only test with `reshape_vectors=True`. As a practical matter, I didn't test with `reshape_vectors=False` because our test infrastructure already present checks that the input vector of a function equals the output of a function. But if `reshape_vectors=False`, since the input is simply too large, the code silently works, producing an output of the correct size (i.e., smaller than the input vector, meaning they're not equal). I didn't want to go through the work of changing `assert_config_works` because it would make the function more complicated, and it seems strange to test that the function gives a "correct" output when you give it an invalid input.