### PR TITLE
Update Catch2 to v3.1.1; Test on ubuntu jammy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-18.04, ubuntu-20.04]
+        os: [ubuntu-18.04, ubuntu-20.04, ubuntu-22.04]
         python: [python3.8, python3.9, python3.10]
         compiler: [
           {C: gcc-5, CXX: g++-5, repos: [
@@ -21,6 +21,13 @@ jobs:
             '"deb http://us.archive.ubuntu.com/ubuntu/ xenial universe"',
           ]},
           {C: gcc-11, CXX: g++-11, repos: ['"ppa:ubuntu-toolchain-r/test"']}]
+        exclude:
+          - os: ubuntu-22.04
+            compiler: {
+              C: gcc-5, CXX: g++-5, repos: [
+                '"deb http://us.archive.ubuntu.com/ubuntu/ xenial main"',
+                '"deb http://us.archive.ubuntu.com/ubuntu/ xenial universe"',
+              ]}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -57,6 +64,14 @@ jobs:
               doxygen \
               libgmp-dev \
               pandoc
+
+      # NOTE(brad): libunwind-dev is a broken dependency of libgoogle-glog-dev, itself
+      # a dependency of ceres. Without this step on jammy, apt-get install libgoogle-glog-dev
+      # would fail. If this step could be removed and still have the build succeed, it should.
+      - name: Fix libunwind-dev install on jammy
+        if: ${{ matrix.os == 'ubuntu-22.04' }}
+        run: |
+          sudo apt-get install -yf libunwind-dev
 
       - name: Install build dependencies for SymForce benchmarks
         run: |

--- a/.github/workflows/test_editable_pip_install.yml
+++ b/.github/workflows/test_editable_pip_install.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, macos-latest]
+        os: [ubuntu-22.04, ubuntu-20.04, macos-latest]
         pip_version: [22.2.2]
         setuptools_version: [65.3.0]
     steps:
@@ -28,15 +28,34 @@ jobs:
           python3 -m pip install pip==${{ matrix.pip_version }}
           python3 -m pip install setuptools==${{ matrix.setuptools_version }}
 
+      # NOTE(brad): There seems to be a bug in pip which prevents editable installation
+      # in user directories. Seems to be resolved in 22.3.0. An alternative which works
+      # for older pip versions is to instead run `pip install --no-use-pep517 -e .` See
+      # https://github.com/pypa/pip/issues/7953 for more info.
+      - name: Update pip
+        if: ${{ matrix.os == 'ubuntu-22.04' }}
+        run: python3 -m pip install pip==22.3.0
+
       - name: editable install
         run: python3 -m pip install -e .
 
-      - name: Set expected install locations for ubuntu
+      - name: Set expected install locations for ubuntu focal
         if: ${{ matrix.os == 'ubuntu-20.04' }}
         run: |
           echo CC_SYM_LOCATION=/home/runner/work/${{ github.event.repository.name }}/${{ github.event.repository.name }}/cc_sym.cpython-38-x86_64-linux-gnu.so >> $GITHUB_ENV
           echo SYM_LOCATION=/home/runner/.local/lib/python3.8/site-packages/sym/__init__.py >> $GITHUB_ENV
           echo SKYMARSHAL_LOCATION=/home/runner/.local/lib/python3.8/site-packages/skymarshal/__init__.py >> $GITHUB_ENV
+          echo SYMENGINE_LOCATION=/home/runner/work/${{ github.event.repository.name }}/${{ github.event.repository.name }}/third_party/symenginepy/symengine/__init__.py >> $GITHUB_ENV
+          echo LCMTYPES_SYM_LOCATION=/home/runner/work/${{ github.event.repository.name }}/${{ github.event.repository.name }}/lcmtypes_build/lcmtypes/sym/__init__.py >> $GITHUB_ENV
+          echo LCMTYPES_EIGENLCM_LOCATION=/home/runner/work/${{ github.event.repository.name }}/${{ github.event.repository.name }}/lcmtypes_build/lcmtypes/eigen_lcm/__init__.py >> $GITHUB_ENV
+          echo SF_SYMPY_LOCATION=/home/runner/work/${{ github.event.repository.name }}/${{ github.event.repository.name }}/third_party/symenginepy/symengine/__init__.py >> $GITHUB_ENV
+
+      - name: Set expected install locations for ubuntu jammy
+        if: ${{ matrix.os == 'ubuntu-22.04' }}
+        run: |
+          echo CC_SYM_LOCATION=/home/runner/work/${{ github.event.repository.name }}/${{ github.event.repository.name }}/cc_sym.cpython-310-x86_64-linux-gnu.so >> $GITHUB_ENV
+          echo SYM_LOCATION=/home/runner/.local/lib/python3.10/site-packages/sym/__init__.py >> $GITHUB_ENV
+          echo SKYMARSHAL_LOCATION=/home/runner/.local/lib/python3.10/site-packages/skymarshal/__init__.py >> $GITHUB_ENV
           echo SYMENGINE_LOCATION=/home/runner/work/${{ github.event.repository.name }}/${{ github.event.repository.name }}/third_party/symenginepy/symengine/__init__.py >> $GITHUB_ENV
           echo LCMTYPES_SYM_LOCATION=/home/runner/work/${{ github.event.repository.name }}/${{ github.event.repository.name }}/lcmtypes_build/lcmtypes/sym/__init__.py >> $GITHUB_ENV
           echo LCMTYPES_EIGENLCM_LOCATION=/home/runner/work/${{ github.event.repository.name }}/${{ github.event.repository.name }}/lcmtypes_build/lcmtypes/eigen_lcm/__init__.py >> $GITHUB_ENV

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -168,14 +168,14 @@ endif()
 # catch2
 
 if(SYMFORCE_BUILD_BENCHMARKS OR SYMFORCE_BUILD_TESTS)
-  find_package(Catch2 3.0.0 QUIET)
+  find_package(Catch2 3 QUIET)
   if(NOT Catch2_FOUND)
     message(STATUS "Catch2 not found, adding with FetchContent")
     function(add_catch)
       FetchContent_Declare(
         Catch2
         GIT_REPOSITORY https://github.com/catchorg/Catch2.git
-        GIT_TAG b9853b4b356b83bb580c746c3a1f11101f9af54f  # v3.0.0-preview3
+        GIT_TAG 5df88da16e276f853cc0c45f4b570419be77dd43  # v3.1.1
       )
 
       FetchContent_MakeAvailable(Catch2)

--- a/setup.py
+++ b/setup.py
@@ -146,20 +146,19 @@ class CMakeBuild(build_ext):
             # in the symenginepy/symengine source directory. Everything is already there
             # except the compiled symengine_wrapper extension module, so we copy that there
             # as well.
+            symengine_wrapper = next(
+                build_temp_path.glob(
+                    f"symengine_install/**/lib/python{sys.version_info.major}.{sys.version_info.minor}/*-packages/symengine/lib/{self.get_ext_filename('symengine_wrapper')}"
+                ),
+                None,
+            )
             # NOTE(brad) For some reason that I don't fully understand, the symengine_wrapper
             # shared library is neither present in symengine_install nor needed in the source
             # directory on macos sometimes (for example, on the github actions macos runner).
-            # So, if the copy fails (due to the file not being present, we just move on).
-            try:
+            # So, if the file's not present, we just move on.
+            if symengine_wrapper:
                 self.copy_file(
-                    build_temp_path
-                    / "symengine_install"
-                    / "lib"
-                    / f"python{sys.version_info.major}.{sys.version_info.minor}"
-                    / "site-packages"
-                    / "symengine"
-                    / "lib"
-                    / self.get_ext_filename("symengine_wrapper"),
+                    symengine_wrapper,
                     SOURCE_DIR
                     / "third_party"
                     / "symenginepy"
@@ -167,8 +166,6 @@ class CMakeBuild(build_ext):
                     / "lib"
                     / self.get_ext_filename("symengine_wrapper"),
                 )
-            except distutils.errors.DistutilsFileError:
-                pass
 
             # NOTE(brad) By setting the RPATH of the generated binaries to include $ORIGIN,
             # we told all binaries they can expect to find any shared libraries in the same

--- a/symforce/pybind/CMakeLists.txt
+++ b/symforce/pybind/CMakeLists.txt
@@ -8,6 +8,9 @@ include(FetchContent)
 find_package(pybind11 QUIET)
 if (NOT pybind11_FOUND)
   message(STATUS "pybind11 not found, adding with FetchContent")
+  # NOTE(brad): Set PYTHON_EXECUTABLE to ensure pybind11 uses the same
+  # python as the rest of symforce.
+  set(PYTHON_EXECUTABLE ${SYMFORCE_PYTHON})
   FetchContent_Declare(
     pybind11
     GIT_REPOSITORY https://github.com/pybind/pybind11


### PR DESCRIPTION
This version of Catch2 doesn't have the same issues that sometimes causes v3.0.1 to fail to compile with older ubuntu versions/compiler versions.

Moreover, it also can compile with newer compilers (like gcc-11) on ubuntu jammy.

So, adding ubuntu jammy to the `test_editable_pip_install` and `ci` github action workflows.

Fixes #132