### PR TITLE
Python 3.11 support

### DIFF
--- a/.github/scripts/expected_paths_test.py
+++ b/.github/scripts/expected_paths_test.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+
+# ----------------------------------------------------------------------------
+# SymForce - Copyright 2022, Skydio, Inc.
+# This source code is under the Apache 2.0 license found in the LICENSE file.
+# ----------------------------------------------------------------------------
+
+import importlib
+import os
+import unittest
+
+
+class SymforceExpectedPathsTest(unittest.TestCase):
+    """
+    Regression test that symforce-related libraries importable from expected paths in CI
+
+    Not a symforce unit test, run specifically from test_editable_pip_install.yml
+    """
+
+    def check_module_location(self, module_name: str) -> None:
+        module = importlib.import_module(module_name)
+        self.assertEqual(
+            module.__file__, os.environ[f"{module_name.upper().replace('.', '_')}_LOCATION"]
+        )
+
+    def test_cc_sym(self) -> None:
+        self.check_module_location("cc_sym")
+
+    def test_sym(self) -> None:
+        self.check_module_location("sym")
+
+    def test_skymarshal(self) -> None:
+        self.check_module_location("skymarshal")
+
+    def test_symengine(self) -> None:
+        self.check_module_location("symengine")
+
+    def test_lcmtypes_sym(self) -> None:
+        self.check_module_location("lcmtypes.sym")
+
+    def test_lcmtypes_eigen_lcm(self) -> None:
+        self.check_module_location("lcmtypes.eigen_lcm")
+
+    def test_sf_sympy(self) -> None:
+        import symforce.symbolic as sf
+
+        self.assertEqual(sf.sympy.__file__, os.environ["SF_SYMPY_LOCATION"])
+
+    def test_symforce_api(self) -> None:
+        import symforce
+
+        self.assertEqual(symforce.get_symbolic_api(), "symengine")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -28,7 +28,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-latest]
-        python-version: [cp38, cp39, cp310]
+        python-version: [cp38, cp39, cp310, cp311]
         arch: [x86_64, arm64]
 
     steps:
@@ -36,7 +36,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Install cibuildwheel
-      run: python3 -m pip install cibuildwheel==2.5.0
+      run: python3 -m pip install cibuildwheel==2.11.2
 
     - name: Build wheels
       run: python3 -m cibuildwheel --output-dir wheelhouse
@@ -59,7 +59,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [cp38, cp39, cp310]
+        python-version: [cp38, cp39, cp310, cp311]
         arch: [x86_64]
 
     steps:
@@ -67,7 +67,7 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Install cibuildwheel
-      run: python3 -m pip install cibuildwheel==2.5.0
+      run: python3 -m pip install cibuildwheel==2.11.2
 
     - name: Build wheels
       run: python3 -m cibuildwheel --output-dir wheelhouse

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-18.04, ubuntu-20.04, ubuntu-22.04]
-        python: [python3.8, python3.9, python3.10]
+        python: [python3.8, python3.9, python3.10, python3.11]
         compiler: [
           {C: gcc-5, CXX: g++-5, repos: [
             '"deb http://us.archive.ubuntu.com/ubuntu/ xenial main"',
@@ -55,7 +55,10 @@ jobs:
       - name: Install python
         run: |
           sudo add-apt-repository -y ppa:deadsnakes/ppa
-          sudo apt-get install -y ${{ matrix.python }}-dev ${{ matrix.python }}-distutils
+          sudo apt-get install -y \
+            ${{ matrix.python }}-dev \
+            ${{ matrix.python }}-distutils \
+            ${{ matrix.python }}-venv
           curl https://bootstrap.pypa.io/get-pip.py | ${{ matrix.python }}
           pip install --upgrade setuptools
 

--- a/.github/workflows/test_editable_pip_install.yml
+++ b/.github/workflows/test_editable_pip_install.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, ubuntu-20.04, macos-latest]
+        os: [ubuntu-22.04, ubuntu-20.04, macos-12]
         pip_version: [22.2.2]
         setuptools_version: [65.3.0]
     steps:
@@ -48,7 +48,7 @@ jobs:
           echo SKYMARSHAL_LOCATION=/home/runner/.local/lib/python3.8/site-packages/skymarshal/__init__.py >> $GITHUB_ENV
           echo SYMENGINE_LOCATION=/home/runner/work/${{ github.event.repository.name }}/${{ github.event.repository.name }}/third_party/symenginepy/symengine/__init__.py >> $GITHUB_ENV
           echo LCMTYPES_SYM_LOCATION=/home/runner/work/${{ github.event.repository.name }}/${{ github.event.repository.name }}/lcmtypes_build/lcmtypes/sym/__init__.py >> $GITHUB_ENV
-          echo LCMTYPES_EIGENLCM_LOCATION=/home/runner/work/${{ github.event.repository.name }}/${{ github.event.repository.name }}/lcmtypes_build/lcmtypes/eigen_lcm/__init__.py >> $GITHUB_ENV
+          echo LCMTYPES_EIGEN_LCM_LOCATION=/home/runner/work/${{ github.event.repository.name }}/${{ github.event.repository.name }}/lcmtypes_build/lcmtypes/eigen_lcm/__init__.py >> $GITHUB_ENV
           echo SF_SYMPY_LOCATION=/home/runner/work/${{ github.event.repository.name }}/${{ github.event.repository.name }}/third_party/symenginepy/symengine/__init__.py >> $GITHUB_ENV
 
       - name: Set expected install locations for ubuntu jammy
@@ -59,40 +59,19 @@ jobs:
           echo SKYMARSHAL_LOCATION=/home/runner/.local/lib/python3.10/site-packages/skymarshal/__init__.py >> $GITHUB_ENV
           echo SYMENGINE_LOCATION=/home/runner/work/${{ github.event.repository.name }}/${{ github.event.repository.name }}/third_party/symenginepy/symengine/__init__.py >> $GITHUB_ENV
           echo LCMTYPES_SYM_LOCATION=/home/runner/work/${{ github.event.repository.name }}/${{ github.event.repository.name }}/lcmtypes_build/lcmtypes/sym/__init__.py >> $GITHUB_ENV
-          echo LCMTYPES_EIGENLCM_LOCATION=/home/runner/work/${{ github.event.repository.name }}/${{ github.event.repository.name }}/lcmtypes_build/lcmtypes/eigen_lcm/__init__.py >> $GITHUB_ENV
+          echo LCMTYPES_EIGEN_LCM_LOCATION=/home/runner/work/${{ github.event.repository.name }}/${{ github.event.repository.name }}/lcmtypes_build/lcmtypes/eigen_lcm/__init__.py >> $GITHUB_ENV
           echo SF_SYMPY_LOCATION=/home/runner/work/${{ github.event.repository.name }}/${{ github.event.repository.name }}/third_party/symenginepy/symengine/__init__.py >> $GITHUB_ENV
 
       - name: Set expected install locations for macos
-        if: ${{ matrix.os == 'macos-latest' }}
+        if: ${{ matrix.os == 'macos-12' }}
         run: |
-          echo CC_SYM_LOCATION=/Users/runner/work/${{ github.event.repository.name }}/${{ github.event.repository.name }}/cc_sym.cpython-310-darwin.so >> $GITHUB_ENV
-          echo SYM_LOCATION=/usr/local/lib/python3.10/site-packages/sym/__init__.py >> $GITHUB_ENV
-          echo SKYMARSHAL_LOCATION=/usr/local/lib/python3.10/site-packages/skymarshal/__init__.py >> $GITHUB_ENV
-          echo SYMENGINE_LOCATION=/usr/local/lib/python3.10/site-packages/symengine/__init__.py >> $GITHUB_ENV
+          echo CC_SYM_LOCATION=/Users/runner/work/${{ github.event.repository.name }}/${{ github.event.repository.name }}/cc_sym.cpython-311-darwin.so >> $GITHUB_ENV
+          echo SYM_LOCATION=/Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages/sym/__init__.py >> $GITHUB_ENV
+          echo SKYMARSHAL_LOCATION=/Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages/skymarshal/__init__.py >> $GITHUB_ENV
+          echo SYMENGINE_LOCATION=/Users/runner/work/${{ github.event.repository.name }}/${{ github.event.repository.name }}/third_party/symenginepy/symengine/__init__.py >> $GITHUB_ENV
           echo LCMTYPES_SYM_LOCATION=/Users/runner/work/${{ github.event.repository.name }}/${{ github.event.repository.name }}/lcmtypes_build/lcmtypes/sym/__init__.py >> $GITHUB_ENV
-          echo LCMTYPES_EIGENLCM_LOCATION=/Users/runner/work/${{ github.event.repository.name }}/${{ github.event.repository.name }}/lcmtypes_build/lcmtypes/eigen_lcm/__init__.py >> $GITHUB_ENV
-          echo SF_SYMPY_LOCATION=/usr/local/lib/python3.10/site-packages/symengine/__init__.py >> $GITHUB_ENV
+          echo LCMTYPES_EIGEN_LCM_LOCATION=/Users/runner/work/${{ github.event.repository.name }}/${{ github.event.repository.name }}/lcmtypes_build/lcmtypes/eigen_lcm/__init__.py >> $GITHUB_ENV
+          echo SF_SYMPY_LOCATION=/Users/runner/work/${{ github.event.repository.name }}/${{ github.event.repository.name }}/third_party/symenginepy/symengine/__init__.py >> $GITHUB_ENV
 
-      - name: Test cc_sym is installed in expected location
-        run: python3 -c "import cc_sym; assert cc_sym.__file__ == '$CC_SYM_LOCATION', cc_sym.__file__"
-
-      - name: Test sym is installed in expected location
-        run: python3 -c "import sym; assert sym.__file__ == '$SYM_LOCATION', sym.__file__"
-
-      - name: Test skymarshal is installed in expected location
-        run: python3 -c "import skymarshal; assert skymarshal.__file__ == '$SKYMARSHAL_LOCATION', skymarshal.__file__"
-
-      - name: Test symengine is installed in expected location
-        run: python3 -c "import symengine; assert symengine.__file__ == '$SYMENGINE_LOCATION', symengine.__file__"
-
-      - name: Test lcmtypes.sym is installed in the expected location
-        run: python3 -c "import lcmtypes.sym; assert lcmtypes.sym.__file__ == '$LCMTYPES_SYM_LOCATION', lcmtypes.sym.__file__"
-
-      - name: Test lcmtypes.eigen_lcm is installed in the expected location
-        run: python3 -c "import lcmtypes.eigen_lcm; assert lcmtypes.eigen_lcm.__file__ == '$LCMTYPES_EIGENLCM_LOCATION', lcmtypes.eigen_lcm.__file__"
-
-      - name: Test symforce.symbolic.sympy returns a package from the expected location
-        run: python3 -c "import symforce.symbolic as sf; assert sf.sympy.__file__ == '$SF_SYMPY_LOCATION', sf.sympy.__file__"
-
-      - name: Check that symengine is default SymForce backend
-        run: python3 -c 'import symforce; assert symforce.get_symbolic_api() == "symengine", symforce.get_symbolic_api()'
+      - name: Test everything is installed in expected locations
+        run: ./.github/scripts/expected_paths_test.py

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -17,11 +17,11 @@ argh==0.26.2
     #   symforce (setup.py)
 astroid==2.12.12
     # via pylint
-asttokens==2.0.8
+asttokens==2.1.0
     # via stack-data
 attrs==22.1.0
     # via jsonschema
-babel==2.10.3
+babel==2.11.0
     # via sphinx
 backcall==0.2.0
     # via ipython
@@ -33,6 +33,8 @@ bleach==5.0.1
     # via nbconvert
 breathe==4.34.0
     # via symforce (setup.py)
+build==0.9.0
+    # via pip-tools
 certifi==2022.9.24
     # via requests
 charset-normalizer==2.1.1
@@ -44,9 +46,9 @@ click==8.0.4
     #   black
     #   pip-tools
     #   symforce (setup.py)
-cmake==3.24.1.1
+cmake==3.24.2
     # via symforce (setup.py)
-contourpy==1.0.5
+contourpy==1.0.6
     # via matplotlib
 coverage==6.5.0
     # via symforce (setup.py)
@@ -70,7 +72,7 @@ docutils==0.19
     #   sphinx
 entrypoints==0.4
     # via jupyter-client
-executing==1.1.1
+executing==1.2.0
     # via stack-data
 fastjsonschema==2.16.2
     # via nbformat
@@ -89,9 +91,9 @@ importlib-metadata==5.0.0
     #   sphinx
 importlib-resources==5.10.0
     # via jsonschema
-ipykernel==6.16.2
+ipykernel==6.17.0
     # via symforce (setup.py)
-ipython==8.5.0
+ipython==8.6.0
     # via
     #   black
     #   ipykernel
@@ -111,7 +113,7 @@ jinja2==3.0.3
     #   skymarshal
     #   sphinx
     #   symforce (setup.py)
-jsonschema==4.16.0
+jsonschema==4.17.0
     # via nbformat
 jupyter-client==7.4.4
     # via
@@ -128,8 +130,10 @@ kiwisolver==1.4.4
     # via matplotlib
 lazy-object-proxy==1.8.0
     # via astroid
-llvmlite==0.39.1
-    # via numba
+llvmlite==0.39.1 ; python_version < "3.11"
+    # via
+    #   numba
+    #   symforce (setup.py)
 markdown-it-py==2.1.0
     # via
     #   mdit-py-plugins
@@ -181,7 +185,7 @@ nest-asyncio==1.5.6
     #   ipykernel
     #   jupyter-client
     #   nbclient
-numba==0.56.3
+numba==0.56.3 ; python_version < "3.11"
     # via symforce (setup.py)
 numpy==1.23.4
     # via
@@ -195,6 +199,7 @@ numpy==1.23.4
     #   symforce-sym
 packaging==21.3
     # via
+    #   build
     #   ipykernel
     #   matplotlib
     #   nbconvert
@@ -208,14 +213,14 @@ parso==0.8.3
 pathspec==0.10.1
     # via black
 pep517==0.13.0
-    # via pip-tools
+    # via build
 pexpect==4.8.0
     # via ipython
 pickleshare==0.7.5
     # via ipython
-pillow==9.2.0
+pillow==9.3.0
     # via matplotlib
-pip-tools==6.6.2
+pip-tools==6.9.0
     # via symforce (setup.py)
 pkgutil-resolve-name==1.3.10
     # via jsonschema
@@ -248,14 +253,14 @@ pyparsing==3.0.9
     # via
     #   matplotlib
     #   packaging
-pyrsistent==0.18.1
+pyrsistent==0.19.1
     # via jsonschema
 python-dateutil==2.8.2
     # via
     #   jupyter-client
     #   matplotlib
     #   pandas
-pytz==2022.5
+pytz==2022.6
     # via
     #   babel
     #   pandas
@@ -302,7 +307,7 @@ sphinxcontrib-qthelp==1.0.3
     # via sphinx
 sphinxcontrib-serializinghtml==1.1.5
     # via sphinx
-stack-data==0.5.1
+stack-data==0.6.0
     # via ipython
 file:./gen/python
     # via symforce (setup.py)
@@ -319,6 +324,7 @@ toml==0.10.2
 tomli==1.2.3
     # via
     #   black
+    #   build
     #   pep517
     #   pylint
 tomlkit==0.11.6

--- a/setup.py
+++ b/setup.py
@@ -481,10 +481,13 @@ setup(
             "isort",
             "jinja2~=3.0.3",
             "mypy==0.910",
-            "numba",
-            # Newer versions of pip-tools use `build`, which has some issues with venv on debian
-            # that we'll need to work around in CI
-            "pip-tools<6.7.0",
+            # Not compatible with py3.11 yet:
+            # https://github.com/aaron-skydio/symforce/actions/runs/3348988114/jobs/5548593278
+            "numba ; python_version < '3.11'",
+            # A dependency of numba, only required here because pip-tools does not automatically
+            # propagate python_version to dependencies
+            "llvmlite ; python_version < '3.11'",
+            "pip-tools",
             "pybind11-stubgen",
             "pylint",
             "types-jinja2",

--- a/test/symforce_codegen_test.py
+++ b/test/symforce_codegen_test.py
@@ -14,7 +14,6 @@ from dataclasses import dataclass
 from pathlib import Path
 
 import numpy as np
-from numba.core.errors import TypingError
 from scipy import sparse
 
 import symforce
@@ -248,10 +247,12 @@ class SymforceCodegenTest(TestCase):
         self.assertEqual(pkg.matrix_order().shape, m23.SHAPE)
         self.assertStorageNear(pkg.matrix_order(), m23)
 
+    @unittest.skipIf(importlib.util.find_spec("numba") is None, "Requires numba")
     def test_matrix_indexing_python(self) -> None:
         """
         Tests that matrices are indexed into correctly.
         """
+        from numba.core.errors import TypingError
 
         def pass_matrices(
             row: sf.M14, col: sf.M41, mat: sf.M22


### PR DESCRIPTION
No actual code changes required, just infra things:

- Unpin and upgrade piptools (requires also installing pythonX-venv in CI, since new piptools uses `build` which needs to create a venv)
- Don't install numba on python3.11 (since it isn't supported yet)
- Upgrade cibuildwheel
- Add python 3.11 to actions matrices

Haven't tested the wheels yet, they're likely fine but we should make sure.