### PR TITLE
Use checkout@v3 everywhere

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -33,7 +33,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Install cibuildwheel
       run: python3 -m pip install cibuildwheel==2.11.2

--- a/gen/python/setup.py
+++ b/gen/python/setup.py
@@ -9,7 +9,7 @@ from setuptools import setup
 
 setup(
     name="symforce-sym",
-    version="0.6.0",
+    version="0.6.1",
     description="generated numerical python package (installed by SymForce)",
     license_file="LICENSE",
     long_description="generated numerical python package (installed by SymForce)",

--- a/symforce/_version.py
+++ b/symforce/_version.py
@@ -3,4 +3,4 @@
 # This source code is under the Apache 2.0 license found in the LICENSE file.
 # ----------------------------------------------------------------------------
 
-version = "0.6.0"
+version = "0.6.1"

--- a/third_party/skymarshal/setup.py
+++ b/third_party/skymarshal/setup.py
@@ -4,5 +4,5 @@ import setuptools
 
 if __name__ == "__main__":
     setuptools.setup(
-        version="0.6.0",
+        version="0.6.1",
     )


### PR DESCRIPTION
Checkout v2 uses node.js 12, which is deprecated

Topic: sym-checkout-v3
Reviewers: hayk-s,bradley,nathan