### PR TITLE
GitHub Actions Workflow Updates

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -1,6 +1,9 @@
 name: Build wheels
 
 on:
+  push:
+    branches:
+     - 'main'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,11 +5,12 @@ on:
     branches:
       - 'main'
   pull_request:
-    types: [opened, synchronize]
+    types: [opened, synchronize, reopened, ready_for_review]
   workflow_dispatch:
 
 jobs:
   test-on-ubuntu:
+    if: github.event.event_name == 'workflow_dispatch' || github.event.pull_request.draft == false
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/test_editable_pip_install.yml
+++ b/.github/workflows/test_editable_pip_install.yml
@@ -5,11 +5,12 @@ on:
     branches:
       - 'main'
   pull_request:
-    types: [opened, synchronize]
+    types: [opened, synchronize, reopened, ready_for_review]
   workflow_dispatch:
 
 jobs:
   editable_install:
+    if: github.event.event_name == 'workflow_dispatch' || github.event.pull_request.draft == false
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false


### PR DESCRIPTION
- Don't run CI jobs on draft PRs
- Build wheels on push to main

Topic: sym-workflows
Reviewers: hayk-skydio,bradley,nathan