### PR TITLE
Add clang to CI, simplify matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,19 +17,32 @@ jobs:
       matrix:
         os: [ubuntu-18.04, ubuntu-20.04, ubuntu-22.04]
         python: [python3.8, python3.9, python3.10, python3.11]
-        compiler: [
-          {C: gcc-5, CXX: g++-5, repos: [
-            '"deb http://us.archive.ubuntu.com/ubuntu/ bionic main"',
-            '"deb http://us.archive.ubuntu.com/ubuntu/ bionic universe"',
-          ]},
-          {C: gcc-11, CXX: g++-11, repos: ['"ppa:ubuntu-toolchain-r/test"']}]
-        exclude:
+        compiler:
+          - C: gcc-11
+            CXX: g++-11
+            repos: ['"ppa:ubuntu-toolchain-r/test"']
+        include:
+          # gcc 5
+          - os: ubuntu-18.04
+            python: python3.8
+            compiler:
+              C: gcc-5
+              CXX: g++-5
+              repos: []
+          # Clang 7
+          - os: ubuntu-18.04
+            python: python3.8
+            compiler:
+              C: clang-7
+              CXX: clang++-7
+              repos: []
+          # Clang 14
           - os: ubuntu-22.04
-            compiler: {
-              C: gcc-5, CXX: g++-5, repos: [
-                '"deb http://us.archive.ubuntu.com/ubuntu/ bionic main"',
-                '"deb http://us.archive.ubuntu.com/ubuntu/ bionic universe"',
-              ]}
+            python: python3.10
+            compiler:
+              C: clang-14
+              CXX: clang++-14
+              repos: []
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
Adds clang 7 and clang 14 to CI.  Also trims down the matrix a bit to
only test gcc 5 with one configuration (bionic, py3.8), which keeps the
full test suite under 20 jobs (the max we can run concurrently for free
on public repos).

clang 6 fails with this error:
https://github.com/aaron-skydio/symforce/actions/runs/3661889498/jobs/6190537015
```
[ 80%] Building CXX object symforce/pybind/CMakeFiles/cc_sym.dir/cc_factor.cc.o
/home/runner/work/symforce/symforce/symforce/pybind/cc_factor.cc:137:12: error: no matching function for call to 'init'
      .def(py::init(&MakeHessianFactor<sym::Key>), py::arg("hessian_func"), py::arg("keys"),
           ^~~~~~~~
/home/runner/work/symforce/symforce/build/_deps/pybind11-src/include/pybind11/pybind11.h:1912:5: note: candidate function [with Func = sym::Factor<double> (*)(std::function<pybind11::tuple (const sym::Values<double> &, const std::vector<sym::index_entry_t, std::allocator<sym::index_entry_t> > &)>, const std::vector<sym::Key, std::allocator<sym::Key> > &, bool), Ret = pybind11::detail::initimpl::factory<sym::Factor<double> (*)(std::function<pybind11::tuple (const sym::Values<double> &, const std::vector<sym::index_entry_t, std::allocator<sym::index_entry_t> > &)>, const std::vector<sym::Key, std::allocator<sym::Key> > &, bool), pybind11::detail::void_type (*)(), sym::Factor<double> (std::function<pybind11::tuple (const sym::Values<double> &, const std::vector<sym::index_entry_t, std::allocator<sym::index_entry_t> > &)>, const std::vector<sym::Key, std::allocator<sym::Key> > &, bool), pybind11::detail::void_type ()>] not viable: no overload of 'MakeHessianFactor' matching 'sym::Factor<double> (*)(std::function<pybind11::tuple (const sym::Values<double> &, const std::vector<sym::index_entry_t, std::allocator<sym::index_entry_t> > &)>, const std::vector<sym::Key, std::allocator<sym::Key> > &, bool)' for 1st argument
Ret init(Func &&f) {
    ^
/home/runner/work/symforce/symforce/build/_deps/pybind11-src/include/pybind11/pybind11.h:1900:40: note: candidate function template not viable: requires 0 arguments, but 1 was provided
detail::initimpl::constructor<Args...> init() {
                                       ^
/home/runner/work/symforce/symforce/build/_deps/pybind11-src/include/pybind11/pybind11.h:1920:5: note: candidate function template not viable: requires 2 arguments, but 1 was provided
Ret init(CFunc &&c, AFunc &&a) {
    ^
/home/runner/work/symforce/symforce/symforce/pybind/cc_factor.cc:148:12: error: no matching function for call to 'init'
      .def(py::init(&MakeHessianFactor<sym::Key, sym::Key>), py::arg("hessian_func"),
           ^~~~~~~~
/home/runner/work/symforce/symforce/build/_deps/pybind11-src/include/pybind11/pybind11.h:1912:5: note: candidate function [with Func = sym::Factor<double> (*)(std::function<pybind11::tuple (const sym::Values<double> &, const std::vector<sym::index_entry_t, std::allocator<sym::index_entry_t> > &)>, const std::vector<sym::Key, std::allocator<sym::Key> > &, const std::vector<sym::Key, std::allocator<sym::Key> > &, bool), Ret = pybind11::detail::initimpl::factory<sym::Factor<double> (*)(std::function<pybind11::tuple (const sym::Values<double> &, const std::vector<sym::index_entry_t, std::allocator<sym::index_entry_t> > &)>, const std::vector<sym::Key, std::allocator<sym::Key> > &, const std::vector<sym::Key, std::allocator<sym::Key> > &, bool), pybind11::detail::void_type (*)(), sym::Factor<double> (std::function<pybind11::tuple (const sym::Values<double> &, const std::vector<sym::index_entry_t, std::allocator<sym::index_entry_t> > &)>, const std::vector<sym::Key, std::allocator<sym::Key> > &, const std::vector<sym::Key, std::allocator<sym::Key> > &, bool), pybind11::detail::void_type ()>] not viable: no overload of 'MakeHessianFactor' matching 'sym::Factor<double> (*)(std::function<pybind11::tuple (const sym::Values<double> &, const std::vector<sym::index_entry_t, std::allocator<sym::index_entry_t> > &)>, const std::vector<sym::Key, std::allocator<sym::Key> > &, const std::vector<sym::Key, std::allocator<sym::Key> > &, bool)' for 1st argument
Ret init(Func &&f) {
    ^
/home/runner/work/symforce/symforce/build/_deps/pybind11-src/include/pybind11/pybind11.h:1900:40: note: candidate function template not viable: requires 0 arguments, but 1 was provided
detail::initimpl::constructor<Args...> init() {
                                       ^
/home/runner/work/symforce/symforce/build/_deps/pybind11-src/include/pybind11/pybind11.h:1920:5: note: candidate function template not viable: requires 2 arguments, but 1 was provided
Ret init(CFunc &&c, AFunc &&a) {
    ^
```
