### PR TITLE
Pass sink parameters by value and move

### DIFF
--- a/symforce/opt/optimizer.h
+++ b/symforce/opt/optimizer.h
@@ -72,34 +72,17 @@ class Optimizer {
   /**
    * Constructor that copies in factors and keys
    */
-  Optimizer(const optimizer_params_t& params, const std::vector<Factor<Scalar>>& factors,
-            const Scalar epsilon = 1e-9, const std::string& name = "sym::Optimize",
-            const std::vector<Key>& keys = {}, bool debug_stats = false,
-            bool check_derivatives = false);
+  Optimizer(const optimizer_params_t& params, std::vector<Factor<Scalar>> factors,
+            const Scalar epsilon = 1e-9, std::string name = "sym::Optimize",
+            std::vector<Key> keys = {}, bool debug_stats = false, bool check_derivatives = false);
 
   /**
    * Constructor that copies in factors and keys, with arguments for the nonlinear solver
    */
   template <typename... NonlinearSolverArgs>
-  Optimizer(const optimizer_params_t& params, const std::vector<Factor<Scalar>>& factors,
-            const Scalar epsilon, const std::string& name, const std::vector<Key>& keys,
-            bool debug_stats, bool check_derivatives, NonlinearSolverArgs&&... args);
-
-  /**
-   * Constructor with move constructors for factors and keys.
-   */
-  Optimizer(const optimizer_params_t& params, std::vector<Factor<Scalar>>&& factors,
-            const Scalar epsilon = 1e-9, const std::string& name = "sym::Optimize",
-            std::vector<Key>&& keys = {}, bool debug_stats = false, bool check_derivatives = false);
-
-  /**
-   * Constructor with move constructors for factors and keys, with arguments for the nonlinear
-   * solver
-   */
-  template <typename... NonlinearSolverArgs>
-  Optimizer(const optimizer_params_t& params, std::vector<Factor<Scalar>>&& factors,
-            const Scalar epsilon, const std::string& name, std::vector<Key>&& keys,
-            bool debug_stats, bool check_derivatives, NonlinearSolverArgs&&... args);
+  Optimizer(const optimizer_params_t& params, std::vector<Factor<Scalar>> factors,
+            const Scalar epsilon, std::string name, std::vector<Key> keys, bool debug_stats,
+            bool check_derivatives, NonlinearSolverArgs&&... args);
 
   // This cannot be moved or copied because the linearization keeps a pointer to the factors
   Optimizer(Optimizer&&) = delete;

--- a/symforce/opt/optimizer.h
+++ b/symforce/opt/optimizer.h
@@ -70,10 +70,10 @@ class Optimizer {
   using NonlinearSolver = NonlinearSolverType;
 
   /**
-   * Constructor that copies in factors and keys
+   * Base constructor
    */
   Optimizer(const optimizer_params_t& params, std::vector<Factor<Scalar>> factors,
-            const Scalar epsilon = 1e-9, std::string name = "sym::Optimize",
+            const Scalar epsilon = 1e-9, const std::string& name = "sym::Optimize",
             std::vector<Key> keys = {}, bool debug_stats = false, bool check_derivatives = false);
 
   /**
@@ -81,7 +81,7 @@ class Optimizer {
    */
   template <typename... NonlinearSolverArgs>
   Optimizer(const optimizer_params_t& params, std::vector<Factor<Scalar>> factors,
-            const Scalar epsilon, std::string name, std::vector<Key> keys, bool debug_stats,
+            const Scalar epsilon, const std::string& name, std::vector<Key> keys, bool debug_stats,
             bool check_derivatives, NonlinearSolverArgs&&... args);
 
   // This cannot be moved or copied because the linearization keeps a pointer to the factors

--- a/symforce/opt/optimizer.tcc
+++ b/symforce/opt/optimizer.tcc
@@ -20,7 +20,7 @@ Optimizer<ScalarType, NonlinearSolverType>::Optimizer(const optimizer_params_t& 
                                                       std::vector<Key> keys, bool debug_stats,
                                                       bool check_derivatives)
     : factors_(std::move(factors)),
-      name_(std::move(name)),
+      name_(name),
       nonlinear_solver_(params, name, epsilon),
       epsilon_(epsilon),
       debug_stats_(debug_stats),

--- a/symforce/opt/optimizer.tcc
+++ b/symforce/opt/optimizer.tcc
@@ -16,7 +16,7 @@ namespace sym {
 template <typename ScalarType, typename NonlinearSolverType>
 Optimizer<ScalarType, NonlinearSolverType>::Optimizer(const optimizer_params_t& params,
                                                       std::vector<Factor<Scalar>> factors,
-                                                      const Scalar epsilon, std::string name,
+                                                      const Scalar epsilon, const std::string& name,
                                                       std::vector<Key> keys, bool debug_stats,
                                                       bool check_derivatives)
     : factors_(std::move(factors)),
@@ -33,10 +33,10 @@ template <typename ScalarType, typename NonlinearSolverType>
 template <typename... NonlinearSolverArgs>
 Optimizer<ScalarType, NonlinearSolverType>::Optimizer(
     const optimizer_params_t& params, std::vector<Factor<Scalar>> factors, const Scalar epsilon,
-    std::string name, std::vector<Key> keys, bool debug_stats, bool check_derivatives,
+    const std::string& name, std::vector<Key> keys, bool debug_stats, bool check_derivatives,
     NonlinearSolverArgs&&... nonlinear_solver_args)
     : factors_(std::move(factors)),
-      name_(std::move(name)),
+      name_(name),
       nonlinear_solver_(params, name, epsilon,
                         std::forward<NonlinearSolverArgs>(nonlinear_solver_args)...),
       epsilon_(epsilon),

--- a/symforce/opt/optimizer.tcc
+++ b/symforce/opt/optimizer.tcc
@@ -15,45 +15,12 @@ namespace sym {
 
 template <typename ScalarType, typename NonlinearSolverType>
 Optimizer<ScalarType, NonlinearSolverType>::Optimizer(const optimizer_params_t& params,
-                                                      const std::vector<Factor<Scalar>>& factors,
-                                                      const Scalar epsilon, const std::string& name,
-                                                      const std::vector<Key>& keys,
-                                                      bool debug_stats, bool check_derivatives)
-    : factors_(factors),
-      name_(name),
-      nonlinear_solver_(params, name, epsilon),
-      epsilon_(epsilon),
-      debug_stats_(debug_stats),
-      keys_(keys.empty() ? ComputeKeysToOptimize(factors_) : keys),
-      index_(),
-      linearizer_(name_, factors_, keys_),
-      linearize_func_(BuildLinearizeFunc(check_derivatives)) {}
-
-template <typename ScalarType, typename NonlinearSolverType>
-template <typename... NonlinearSolverArgs>
-Optimizer<ScalarType, NonlinearSolverType>::Optimizer(
-    const optimizer_params_t& params, const std::vector<Factor<Scalar>>& factors,
-    const Scalar epsilon, const std::string& name, const std::vector<Key>& keys, bool debug_stats,
-    bool check_derivatives, NonlinearSolverArgs&&... nonlinear_solver_args)
-    : factors_(factors),
-      name_(name),
-      nonlinear_solver_(params, name, epsilon,
-                        std::forward<NonlinearSolverArgs>(nonlinear_solver_args)...),
-      epsilon_(epsilon),
-      debug_stats_(debug_stats),
-      keys_(keys.empty() ? ComputeKeysToOptimize(factors_) : keys),
-      index_(),
-      linearizer_(name_, factors_, keys_),
-      linearize_func_(BuildLinearizeFunc(check_derivatives)) {}
-
-template <typename ScalarType, typename NonlinearSolverType>
-Optimizer<ScalarType, NonlinearSolverType>::Optimizer(const optimizer_params_t& params,
-                                                      std::vector<Factor<Scalar>>&& factors,
-                                                      const Scalar epsilon, const std::string& name,
-                                                      std::vector<Key>&& keys, bool debug_stats,
+                                                      std::vector<Factor<Scalar>> factors,
+                                                      const Scalar epsilon, std::string name,
+                                                      std::vector<Key> keys, bool debug_stats,
                                                       bool check_derivatives)
     : factors_(std::move(factors)),
-      name_(name),
+      name_(std::move(name)),
       nonlinear_solver_(params, name, epsilon),
       epsilon_(epsilon),
       debug_stats_(debug_stats),
@@ -65,10 +32,11 @@ Optimizer<ScalarType, NonlinearSolverType>::Optimizer(const optimizer_params_t& 
 template <typename ScalarType, typename NonlinearSolverType>
 template <typename... NonlinearSolverArgs>
 Optimizer<ScalarType, NonlinearSolverType>::Optimizer(
-    const optimizer_params_t& params, std::vector<Factor<Scalar>>&& factors, const Scalar epsilon,
-    const std::string& name, std::vector<Key>&& keys, bool debug_stats, bool check_derivatives,
+    const optimizer_params_t& params, std::vector<Factor<Scalar>> factors, const Scalar epsilon,
+    std::string name, std::vector<Key> keys, bool debug_stats, bool check_derivatives,
     NonlinearSolverArgs&&... nonlinear_solver_args)
     : factors_(std::move(factors)),
+      name_(std::move(name)),
       nonlinear_solver_(params, name, epsilon,
                         std::forward<NonlinearSolverArgs>(nonlinear_solver_args)...),
       epsilon_(epsilon),


### PR DESCRIPTION
Optimizer has 2 sink parameters (factors and keys) but only provides 2 overloads. This is sub-optimal as we really need 4 overloads to cover all cases (LL, LR, RL, RR). It is just much easier and cleaner to pass by value and move.

