### PR TITLE
Remove Factor constructor/creation overloads that takes only keys

### DIFF
--- a/symforce/opt/factor.cc
+++ b/symforce/opt/factor.cc
@@ -41,18 +41,10 @@ Factor<Scalar>::Factor(const DenseJacobianFunc& jacobian_func, const std::vector
     : Factor(HessianFuncFromJacobianFunc<Scalar>(jacobian_func), keys_to_func, keys_to_optimize) {}
 
 template <typename Scalar>
-Factor<Scalar>::Factor(const DenseJacobianFunc& jacobian_func, const std::vector<Key>& keys)
-    : Factor(HessianFuncFromJacobianFunc<Scalar>(jacobian_func), keys) {}
-
-template <typename Scalar>
 Factor<Scalar>::Factor(const SparseJacobianFunc& jacobian_func,
                        const std::vector<Key>& keys_to_func,
                        const std::vector<Key>& keys_to_optimize)
     : Factor(HessianFuncFromJacobianFunc<Scalar>(jacobian_func), keys_to_func, keys_to_optimize) {}
-
-template <typename Scalar>
-Factor<Scalar>::Factor(const SparseJacobianFunc& jacobian_func, const std::vector<Key>& keys)
-    : Factor(HessianFuncFromJacobianFunc<Scalar>(jacobian_func), keys) {}
 
 template <typename Scalar>
 void Factor<Scalar>::Linearize(const Values<Scalar>& values, VectorX<Scalar>* residual) const {

--- a/symforce/opt/factor.h
+++ b/symforce/opt/factor.h
@@ -105,15 +105,7 @@ class Factor {
   // Constructors
   // ----------------------------------------------------------------------------------------------
 
-  Factor() {}
-
-  /**
-   * Create directly from a (dense) hessian functor. This is the lowest-level constructor.
-   *
-   * Args:
-   *   keys_to_func: The set of input arguments, in order, accepted by func.
-   */
-  Factor(DenseHessianFunc hessian_func, const std::vector<Key>& keys);
+  Factor() = default;
 
   /**
    * Create directly from a (sparse) hessian functor. This is the lowest-level constructor.
@@ -124,10 +116,9 @@ class Factor {
    *                     be a subset of keys_to_func.
    */
   Factor(DenseHessianFunc hessian_func, const std::vector<Key>& keys_to_func,
-         const std::vector<Key>& keys_to_optimize);
-  Factor(SparseHessianFunc hessian_func, const std::vector<Key>& keys_to_func);
+         const std::vector<Key>& keys_to_optimize = {});
   Factor(SparseHessianFunc hessian_func, const std::vector<Key>& keys_to_func,
-         const std::vector<Key>& keys_to_optimize);
+         const std::vector<Key>& keys_to_optimize = {});
 
   /**
    * Does this factor use a sparse jacobian/hessian matrix?
@@ -144,33 +135,11 @@ class Factor {
    *
    * Args:
    *   keys_to_func: The set of input arguments, in order, accepted by func.
-   */
-  Factor(const DenseJacobianFunc& jacobian_func, const std::vector<Key>& keys);
-
-  /**
-   * Create from a function that computes the (dense) jacobian. The hessian will be computed using
-   * the Gauss Newton approximation:
-   *    H   = J.T * J
-   *    rhs = J.T * b
-   *
-   * Args:
-   *   keys_to_func: The set of input arguments, in order, accepted by func.
    *   keys_to_optimize: The set of input arguments that correspond to the derivative in func. Must
    *                     be a subset of keys_to_func.
    */
   Factor(const DenseJacobianFunc& jacobian_func, const std::vector<Key>& keys_to_func,
-         const std::vector<Key>& keys_to_optimize);
-
-  /**
-   * Create from a function that computes the (sparse) jacobian. The hessian will be computed using
-   * the Gauss Newton approximation:
-   *    H   = J.T * J
-   *    rhs = J.T * b
-   *
-   * Args:
-   *   keys_to_func: The set of input arguments, in order, accepted by func.
-   */
-  Factor(const SparseJacobianFunc& jacobian_func, const std::vector<Key>& keys);
+         const std::vector<Key>& keys_to_optimize = {});
 
   /**
    * Create from a function that computes the (sparse) jacobian. The hessian will be computed using
@@ -184,28 +153,7 @@ class Factor {
    *                     be a subset of keys_to_func.
    */
   Factor(const SparseJacobianFunc& jacobian_func, const std::vector<Key>& keys_to_func,
-         const std::vector<Key>& keys_to_optimize);
-
-  /**
-   * Create from a function that computes the jacobian. The hessian will be computed using the
-   * Gauss Newton approximation:
-   *    H   = J.T * J
-   *    rhs = J.T * b
-   *
-   * This version handles a variety of functors that take in individual input arguments
-   * rather than a Values object - the last two arguments to `func` should be outputs for the
-   * residual and jacobian; arguments before that should be inputs to `func`.
-   *
-   * If generating this factor from a single Python function, you probably want to use the
-   * Factor::Hessian constructor instead (it'll likely result in faster linearization).  If you
-   * really want to generate a factor and use this constructor, `func` can be generated easily by
-   * creating a Codegen object from a Python function which returns the residual, then calling
-   * with_linearization with linearization_mode=STACKED_JACOBIAN
-   *
-   * See `symforce_factor_test.cc` for many examples.
-   */
-  template <typename Functor>
-  static Factor Jacobian(Functor&& func, const std::vector<Key>& keys);
+         const std::vector<Key>& keys_to_optimize = {});
 
   /**
    * Same as the above, but allows extra constant keys into the function which are not optimized.
@@ -218,25 +166,7 @@ class Factor {
    */
   template <typename Functor>
   static Factor Jacobian(Functor&& func, const std::vector<Key>& keys_to_func,
-                         const std::vector<Key>& keys_to_optimize);
-
-  /**
-   * Create from a functor that computes the full linearization, but takes in individual input
-   * arguments rather than a Values object.  The last four arguments to `func` should be outputs for
-   * the residual, jacobian, hessian, and rhs; arguments before that should be inputs to `func`.
-   *
-   * This should be used in cases where computing J^T J using a matrix multiplication is slower than
-   * evaluating J^T J symbolically; for instance, if the jacobian is sparse or J^T J has structure
-   * so that CSE is very effective.
-   *
-   * `func` can be generated easily by creating a Codegen object from a Python function which
-   * returns the residual, then calling with_linearization with
-   * linearization_mode=FULL_LINEARIZATION (the default)
-   *
-   * See `symforce_factor_test.cc` for many examples.
-   */
-  template <typename Functor>
-  static Factor Hessian(Functor&& func, const std::vector<Key>& keys);
+                         const std::vector<Key>& keys_to_optimize = {});
 
   /**
    * Same as the above, but allows extra constant keys into the function which are not optimized.
@@ -249,7 +179,7 @@ class Factor {
    */
   template <typename Functor>
   static Factor Hessian(Functor&& func, const std::vector<Key>& keys_to_func,
-                        const std::vector<Key>& keys_to_optimize);
+                        const std::vector<Key>& keys_to_optimize = {});
 
   // ----------------------------------------------------------------------------------------------
   // Linearization

--- a/symforce/opt/factor.tcc
+++ b/symforce/opt/factor.tcc
@@ -10,21 +10,13 @@
 namespace sym {
 
 template <typename Scalar>
-Factor<Scalar>::Factor(DenseHessianFunc hessian_func, const std::vector<Key>& keys)
-    : Factor(std::move(hessian_func), keys, keys) {}
-
-template <typename Scalar>
 Factor<Scalar>::Factor(DenseHessianFunc hessian_func, const std::vector<Key>& keys_to_func,
                        const std::vector<Key>& keys_to_optimize)
     : hessian_func_(std::move(hessian_func)),
       sparse_hessian_func_(),
       is_sparse_(false),
-      keys_to_optimize_(keys_to_optimize),
+      keys_to_optimize_(keys_to_optimize.empty() ? keys_to_func : keys_to_optimize),
       keys_(keys_to_func) {}
-
-template <typename Scalar>
-Factor<Scalar>::Factor(SparseHessianFunc sparse_hessian_func, const std::vector<Key>& keys)
-    : Factor(std::move(sparse_hessian_func), keys, keys) {}
 
 template <typename Scalar>
 Factor<Scalar>::Factor(SparseHessianFunc sparse_hessian_func, const std::vector<Key>& keys_to_func,
@@ -32,7 +24,7 @@ Factor<Scalar>::Factor(SparseHessianFunc sparse_hessian_func, const std::vector<
     : hessian_func_(),
       sparse_hessian_func_(std::move(sparse_hessian_func)),
       is_sparse_(true),
-      keys_to_optimize_(keys_to_optimize),
+      keys_to_optimize_(keys_to_optimize.empty() ? keys_to_func : keys_to_optimize),
       keys_(keys_to_func) {}
 
 // ------------------------------------------------------------------------------------------------
@@ -42,12 +34,6 @@ Factor<Scalar>::Factor(SparseHessianFunc sparse_hessian_func, const std::vector<
 // understand its input/output arguments, performs a series of static assertions, and dispatches
 // to the correct helper to be processed.
 // ------------------------------------------------------------------------------------------------
-
-template <typename Scalar>
-template <typename Functor>
-Factor<Scalar> Factor<Scalar>::Jacobian(Functor&& func, const std::vector<Key>& keys) {
-  return Jacobian(std::forward<Functor>(func), keys, keys);
-}
 
 template <typename Scalar>
 template <typename Functor>
@@ -100,12 +86,6 @@ Factor<Scalar> Factor<Scalar>::Jacobian(Functor&& func, const std::vector<Key>& 
 // understand its input/output arguments, performs a series of static assertions, and dispatches
 // to the correct helper to be processed.
 // ------------------------------------------------------------------------------------------------
-
-template <typename Scalar>
-template <typename Functor>
-Factor<Scalar> Factor<Scalar>::Hessian(Functor&& func, const std::vector<Key>& keys) {
-  return Hessian(std::forward<Functor>(func), keys, keys);
-}
 
 template <typename Scalar>
 template <typename Functor>


### PR DESCRIPTION
This is the first step among several to try to encapsulate `keys` and `keys_to_optimize` into a class called `FactorKeys` (open to better names).
So that all Factor creation functions will just take a `Func` and `FactorKeys`. 
I have a rough plan of how to implement `FactorKeys` and I'm also open to other suggestions.

But for now, I just want to remove some of the (what I deem to be unnecessary) overloads in Factor creation functions to reduce the API surface area for future refactoring.


