### PR TITLE
Check sparse matrix condition for Jacobian and Hessian constructors

### DIFF
--- a/symforce/opt/factor.tcc
+++ b/symforce/opt/factor.tcc
@@ -69,7 +69,7 @@ Factor<Scalar> Factor<Scalar>::Jacobian(Functor&& func, const std::vector<Key>& 
                 "JacobianMat (last argument) should be an Eigen::Matrix or Eigen::SparseMatrix");
 
   // Check sparse vs dense
-  constexpr bool is_sparse = !kIsEigenType<JacobianMat>;
+  constexpr bool is_sparse = kIsSparseEigenType<JacobianMat>;
 
   // Get dimensions
   constexpr int M = ResidualVec::RowsAtCompileTime;
@@ -132,8 +132,8 @@ Factor<Scalar> Factor<Scalar>::Hessian(Functor&& func, const std::vector<Key>& k
   static_assert(kIsEigenType<RhsVec>, "RhsVec (last argument) should be an Eigen::Matrix");
 
   // Check sparse vs dense
-  constexpr bool jacobian_is_sparse = !kIsEigenType<JacobianMat>;
-  constexpr bool hessian_is_sparse = !kIsEigenType<HessianMat>;
+  constexpr bool jacobian_is_sparse = kIsSparseEigenType<JacobianMat>;
+  constexpr bool hessian_is_sparse = kIsSparseEigenType<HessianMat>;
   static_assert(jacobian_is_sparse == hessian_is_sparse,
                 "Matrices cannot be mixed dense and sparse.");
 


### PR DESCRIPTION
Hi, a keen user of symforce here!

Found some code that may lead to some confusion in the future.
Suggesting a change for that.

Best,
changh95

---

- Variable `jacobian_is_sparse` should really be `kIsSparseEigenType<T>()` instead of `!kIsEigenType<T>()`
- So is for `hessian_is_sparse`