### PR TITLE
Set min version of lazy-object-proxy to 1.9.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,15 @@ jobs:
           - C: gcc-11
             CXX: g++-11
             repos: ['"ppa:ubuntu-toolchain-r/test"']
+        exclude:
+          # NOTE(brad): No available pre-built wheel for lazy-object-proxy==1.9.0 for this
+          # combination. Local-build fails on pip 23.0.0, so we skip the test. Root cause of issue
+          # seems to come from https://github.com/pypa/pip/pull/11598, as
+          # sysconfig.get_paths(vars=vars, scheme="venv") gives the wrong paths. To build anyway,
+          # either modify pip to not take "venv" path, or just use pip 22.3.1 (version before this
+          # was added).
+          - os: ubuntu-18.04
+            python: python3.11
         include:
           # gcc 5
           - os: ubuntu-18.04

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -131,8 +131,10 @@ jupyterlab-pygments==0.2.2
     # via nbconvert
 kiwisolver==1.4.4
     # via matplotlib
-lazy-object-proxy==1.8.0
-    # via astroid
+lazy-object-proxy==1.9.0
+    # via
+    #   astroid
+    #   symforce (setup.py)
 llvmlite==0.39.1 ; python_version < "3.11"
     # via
     #   numba

--- a/setup.py
+++ b/setup.py
@@ -491,6 +491,8 @@ setup(
             "pip-tools<6.11",
             "pybind11-stubgen",
             "pylint",
+            # NOTE(brad): A transitive dependency of pylint. Added here only to pin the version.
+            "lazy-object-proxy>=1.9.0",
             "types-jinja2",
             "types-pygments",
             "types-requests",


### PR DESCRIPTION
This is because lazy-object-proxy does not have built wheels on pypa for
linux on version 1.8.0, and for some reason running it's setup.py can
fail when done locally.

Also, for some reason, a pre-built wheel for the same package is not
available for python3.11 on bionic (even for version 1.9.0). Note,
lazy-object-proxy can be built on pip 22.3.1 (but not on the current
latest, 23.0.0). Suspect this is a bug on pip's end, but if not, then
it's probably a bug on lazy-object-proxy's end. Anyway, because we don't
want to contort our code around other package's problems, I am just
removing the python3.11 on bionic tests. If for some reason you do need
build on python3.11 on bionic, just set your pip version to 22.3.1 then
try again. Should work (not just for this pair but more generally).

Topic: get_CI_workflow_passing_again