### PR TITLE
Add explicit instantiation declaration for Values

### DIFF
--- a/symforce/opt/values.h
+++ b/symforce/opt/values.h
@@ -275,3 +275,7 @@ std::ostream& operator<<(std::ostream& os, const Values<Scalar>& v);
 
 // Template method implementations
 #include "./values.tcc"
+
+// Explicit instantiation declarations
+extern template class sym::Values<double>;
+extern template class sym::Values<float>;


### PR DESCRIPTION
For some reason this was missing (despite the fact that we explicitly
instantiate the class in `values.cc`)

Speculation, but this might be why `values.h` always takes so long to
compile.

Topic: values_explicit_instantiation_declaration