### PR TITLE
Use URL for FetchContent

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -129,6 +129,12 @@ endif()
 # Third Party Dependencies (needed for build)
 # ==============================================================================
 
+# NOTE(aaron): Generally, for third party dependencies we will use already-installed versions if
+# available via find_package, and if not pull with FetchContent.  In CMake 3.24, FetchContent can
+# do this check automatically, so this logic could be simplified:
+# https://www.kitware.com/cmake-3-24-0-is-available-for-download/
+# We use URL downloads with FetchContent, because GIT downloads do not have a way to do shallow
+# clones with specific commits
 include(FetchContent)
 
 # ------------------------------------------------------------------------------
@@ -141,9 +147,8 @@ if(SYMFORCE_EIGEN_TARGET STREQUAL "Eigen3::Eigen")
     function(add_eigen)
       FetchContent_Declare(
         eigen3
-        GIT_REPOSITORY https://gitlab.com/libeigen/eigen
-        GIT_TAG 3147391d946bb4b6c68edd901f2add6ac1f31f8c  # release 3.4.0
-        GIT_SHALLOW TRUE
+        URL https://gitlab.com/libeigen/eigen/-/archive/3.4.0/eigen-3.4.0.tar.gz
+        URL_HASH SHA256=8586084f71f9bde545ee7fa6d00288b264a2b7ac3607b974e54d13e7162c1c72
       )
 
       set(EIGEN_BUILD_DOC OFF CACHE BOOL "Don't build Eigen docs")
@@ -174,8 +179,8 @@ if(SYMFORCE_BUILD_BENCHMARKS OR SYMFORCE_BUILD_TESTS)
     function(add_catch)
       FetchContent_Declare(
         Catch2
-        GIT_REPOSITORY https://github.com/catchorg/Catch2.git
-        GIT_TAG 5df88da16e276f853cc0c45f4b570419be77dd43  # v3.1.1
+        URL https://github.com/catchorg/Catch2/archive/refs/tags/v3.1.1.zip
+        URL_HASH SHA256=eec6c327cd9187c63bbaaa8486f715e31544000bf8876c0543e1181a2a52a5de
       )
 
       FetchContent_MakeAvailable(Catch2)

--- a/symforce/benchmarks/CMakeLists.txt
+++ b/symforce/benchmarks/CMakeLists.txt
@@ -20,9 +20,8 @@ if (NOT Sophus_FOUND)
     set(CMAKE_POSITION_INDEPENDENT_CODE True)
     FetchContent_Declare(
       sophus
-      GIT_REPOSITORY https://github.com/strasdat/Sophus
-      GIT_TAG v1.0.0
-      GIT_SHALLOW TRUE
+      URL https://github.com/strasdat/Sophus/archive/refs/tags/v1.0.0.zip
+      URL_HASH SHA256=60c8a18f750fdfd75c828253c8f123fac15493ced0baaee8a19df64a4acbf548
     )
     FetchContent_MakeAvailable(sophus)
     find_package(Sophus)
@@ -57,9 +56,8 @@ if (NOT gtsam_FOUND)
     set(CMAKE_POSITION_INDEPENDENT_CODE True)
     FetchContent_Declare(
       gtsam
-      GIT_REPOSITORY https://github.com/borglab/gtsam
-      GIT_TAG 4.1.1
-      GIT_SHALLOW TRUE
+      URL https://github.com/borglab/gtsam/archive/refs/tags/4.1.1.zip
+      URL_HASH SHA256=f03cd72884647aaa0a24df5ee262ad0824b343554c763d81b2957836f4cab99d
     )
     FetchContent_MakeAvailable(gtsam)
   endfunction()
@@ -90,9 +88,8 @@ if (NOT Ceres_FOUND)
     set(CMAKE_POSITION_INDEPENDENT_CODE True)
     FetchContent_Declare(
       ceres
-      GIT_REPOSITORY https://github.com/ceres-solver/ceres-solver
-      GIT_TAG 2.0.0
-      GIT_SHALLOW TRUE
+      URL https://github.com/ceres-solver/ceres-solver/archive/refs/tags/2.0.0.zip
+      URL_HASH SHA256=db12d37b4cebb26353ae5b7746c7985e00877baa8e7b12dc4d3a1512252fff3b
     )
     FetchContent_MakeAvailable(ceres)
   endfunction()

--- a/symforce/opt/CMakeLists.txt
+++ b/symforce/opt/CMakeLists.txt
@@ -19,9 +19,8 @@ if (NOT fmt_FOUND)
     set(FMT_INSTALL ON CACHE INTERNAL "fmt should create an install target")
     FetchContent_Declare(
       fmtlib
-      GIT_REPOSITORY https://github.com/fmtlib/fmt
-      GIT_TAG d141cdbeb0fb422a3fb7173b285fd38e0d1772dc # release 8.0.1
-      GIT_SHALLOW TRUE
+      URL https://github.com/fmtlib/fmt/archive/8.0.1.zip
+      URL_HASH SHA256=6747442c189064b857336007dd7fa3aaf58512aa1a0b2ba76bf1182eefb01025
     )
     set(CMAKE_POSITION_INDEPENDENT_CODE True)
     FetchContent_MakeAvailable(fmtlib)
@@ -44,9 +43,8 @@ if (NOT spdlog_FOUND)
     set(CMAKE_POSITION_INDEPENDENT_CODE True)
     FetchContent_Declare(
       spdlog
-      GIT_REPOSITORY https://github.com/gabime/spdlog
-      GIT_TAG v1.9.2
-      GIT_SHALLOW TRUE
+      URL https://github.com/gabime/spdlog/archive/v1.9.2.zip
+      URL_HASH SHA256=130bd593c33e2e2abba095b551db6a05f5e4a5a19c03ab31256c38fa218aa0a6
     )
     FetchContent_MakeAvailable(spdlog)
   endfunction()
@@ -66,10 +64,8 @@ if (NOT tl_optional_FOUND)
     set(OPTIONAL_BUILD_TESTS OFF CACHE INTERNAL "tl::optional shouldn't build tests")
     FetchContent_Declare(
       tl_optional
-      GIT_REPOSITORY https://github.com/TartanLlama/optional
-      # NOTE: This pulls in TartanLlama/optional#45, which is not yet in any tagged releases.
-      GIT_TAG c28fcf74d207fc667c4ed3dbae4c251ea551c8c1
-      GIT_SHALLOW TRUE
+      URL https://github.com/TartanLlama/optional/archive/v1.1.0.zip
+      URL_HASH SHA256=a336bb10f51945369c1dd6dc6d2a7086602ab9cab52c98a7a6224bfd782bc0c7
     )
     FetchContent_MakeAvailable(tl_optional)
 
@@ -93,6 +89,7 @@ function(add_metis)
     # github, which is newer than the release on the METIS website. All of the releases on github
     # seem to have memory bugs, which do not appear in this release:
     URL https://symforce-org.github.io/downloads/metis-5.1.0.tar.gz
+    URL_HASH SHA256=76faebe03f6c963127dbb73c13eab58c9a3faeae48779f049066a21c087c5db2
     # GKlib builds some test executables we can't disable without patching
     PATCH_COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/../../cmake/patch_metis.sh" "${FETCHCONTENT_BASE_DIR}/metis-src"
   )

--- a/symforce/pybind/CMakeLists.txt
+++ b/symforce/pybind/CMakeLists.txt
@@ -17,8 +17,8 @@ if (NOT pybind11_FOUND)
   set(PYTHON_EXECUTABLE ${SYMFORCE_PYTHON})
   FetchContent_Declare(
     pybind11
-    GIT_REPOSITORY https://github.com/pybind/pybind11
-    GIT_TAG 914c06fb252b6cc3727d0eedab6736e88a3fcb01 # release 2.9.2
+    URL https://github.com/pybind/pybind11/archive/v2.9.2.zip
+    URL_HASH SHA256=d1646e6f70d8a3acb2ddd85ce1ed543b5dd579c68b8fb8e9638282af20edead8
   )
   FetchContent_MakeAvailable(pybind11)
 else()


### PR DESCRIPTION
Use URL and URL_HASH for everything, for the reasons described in the
comment.  Versions of everything are unchanged, except for tl::optional,
which is now on an actual release (1.1.0).

Tested locally that this works with no dependencies installed on the
system, with cmake 3.20 (cmake 3.19 doesn't seem to be available on pypi
anymore)

Topic: fetchcontent-url-download