### PR TITLE
Install symforce slam

### DIFF
--- a/symforce/slam/CMakeLists.txt
+++ b/symforce/slam/CMakeLists.txt
@@ -22,3 +22,6 @@ target_link_libraries(symforce_slam
   symforce_opt
   ${SYMFORCE_EIGEN_TARGET}
 )
+
+install(TARGETS symforce_slam DESTINATION lib)
+install(DIRECTORY ./ DESTINATION include/symforce/slam FILES_MATCHING PATTERN "*.h" PATTERN "*.tcc")


### PR DESCRIPTION
Install the symforce slam library such that this can be used in standalone CMake projects. E.g. to include the IMU factor.

I've used the same approach as in the installation of [symforce_opt](https://github.com/symforce-org/symforce/blob/7b2210832bf53a9645473620f7cdd966dd2a490a/CMakeLists.txt#L283-L284) and [symforce_gen](https://github.com/johhat/symforce/blob/7b2210832bf53a9645473620f7cdd966dd2a490a/symforce/opt/CMakeLists.txt#L166-L167).

The pattern matching picks up both .h files and .tcc files, but the latter has no effect at the moment since no .tcc files are present.