### PR TITLE
Use Codegen.name as python function name

### DIFF
--- a/symforce/codegen/backends/python/templates/util/util.jinja
+++ b/symforce/codegen/backends/python/templates/util/util.jinja
@@ -91,7 +91,7 @@
  #     spec (Codegen):
  #}
 {%- macro function_name_and_args(spec) -%}
-{{ camelcase_to_snakecase(spec.name) }}(
+{{ spec.name }}(
 {%- for name in spec.inputs.keys() -%}
 {{ name }}{% if not loop.last %}, {% endif %}
 {%- endfor -%})

--- a/symforce/codegen/backends/pytorch/templates/util/util.jinja
+++ b/symforce/codegen/backends/pytorch/templates/util/util.jinja
@@ -98,7 +98,7 @@ default to the device and dtype of the first input tensor, or the empty dict if 
  #     spec (Codegen):
  #}
 {%- macro function_name_and_args(spec) -%}
-{{ camelcase_to_snakecase(spec.name) }}(
+{{ spec.name }}(
 {%- for name in spec.inputs.keys() -%}
 {{ name }},{{ ' ' }}
 {%- endfor -%}tensor_kwargs = None)

--- a/symforce/opt/numeric_factor.py
+++ b/symforce/opt/numeric_factor.py
@@ -48,7 +48,9 @@ class NumericFactor:
         name: str,
     ) -> NumericFactor:
         """
-        Loads a generated python linearization function from a given file. This can be used after
+        Returns a NumericFactor constructed from the python function `name` from the module
+        located at `output_dir / "python" / "symforce" / namespace / f"{name}.py"` (this matches
+        the directory structure created by `Factor.generate`). This can be used after
         generating a linearization function from a symbolic factor as follows:
 
         Create a symbolic factor and generate the linearization function:


### PR DESCRIPTION
BREAKING CHANGE: User generated python function names will change.

Previously we would call `symforce.python_util.camelcase_to_snakecase`
on the name of a `Codegen` object to use as the name of the generated
function. Meanwhile, we would use the name of the `Codegen` object,
unmodified, as the name of the python file (unless the
`generated_file_name` argument is provided to
`Codegen.generate_function`, in which case we use that).

Unfortunately, in a number of places (like in `numeric_factor.py` and
`factor.py`) we assume that the name of the generated function matches
the name of the generated file it lives in. (Resulting in things
breaking if the name of the `Codegen` object is not already in
snake_case).

An example of this is `Factor.generate`.

To address this, in this commit I change the jinja template to use the
`Codegen.name` as the generated function name. This way, in the default
case, the generated function will match the file name. It also has the
benefit of offering the user more flexibility to set the name of their
generated functions.

Note, if `Codegen.with_linearization` is used, `_factor` is appended to
all names (so you might end up with a residual whose name and file is
`CamelCase_factor`).

Fixes: #299

Topic: issue_299