### PR TITLE
Added example code for initialization of sf.Rot3 using a quaternion

### DIFF
--- a/notebooks/tutorials/geometry_tutorial.ipynb
+++ b/notebooks/tutorials/geometry_tutorial.ipynb
@@ -75,34 +75,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# from a quaternion\n",
-    "\n",
-    "# for a quaternion of the form qs + qv0 + qv1 + qv2 we can represent it in symforce using a sf.Quaternion \n",
+    "# from a quaternion of the form qs + qv0 + qv1 + qv2 - we can represent it in symforce using a sf.Quaternion \n",
     "qv = sf.V3.symbolic(\"qv\")\n",
     "qw = sf.Symbol(\"qs\")\n",
     "quat = sf.Quaternion(xyz=qv, w = qw)\n",
-    "display(quat)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
+    "display(quat)\n",
     "# we can use this quaternion to initialize Rotation of Lie group a sf.Rot3 \n",
     "R_from_quat = sf.Rot3(quat)\n",
     "display(R_from_quat)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "R_from_quat_numeric = sf.Rot3(sf.Quaternion(xyz = sf.V3([0.0, 0.0, 1.0]), w = 0.0))\n",
-    "display(R_from_quat_numeric)"
    ]
   },
   {
@@ -752,7 +732,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.2"
+   "version": "3.10.6"
   },
   "mimetype": "text/x-python",
   "name": "python",

--- a/notebooks/tutorials/geometry_tutorial.ipynb
+++ b/notebooks/tutorials/geometry_tutorial.ipynb
@@ -75,6 +75,42 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# from a quaternion\n",
+    "\n",
+    "# for a quaternion of the form qs + qv0 + qv1 + qv2 we can represent it in symforce using a sf.Quaternion \n",
+    "qv = sf.V3.symbolic(\"qv\")\n",
+    "qw = sf.Symbol(\"qs\")\n",
+    "quat = sf.Quaternion(xyz=qv, w = qw)\n",
+    "display(quat)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# we can use this quaternion to initialize Rotation of Lie group a sf.Rot3 \n",
+    "R_from_quat = sf.Rot3(quat)\n",
+    "display(R_from_quat)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "R_from_quat_numeric = sf.Rot3(sf.Quaternion(xyz = sf.V3([0.0, 0.0, 1.0]), w = 0.0))\n",
+    "display(R_from_quat_numeric)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "# To/From rotation matrix\n",
     "\n",
     "# Rotate about x-axis\n",


### PR DESCRIPTION
Added initialisation of a ```sf.Rot3``` Lie Group using ```sf.Quaternion``` - symbolic as well as numeric - to the geometry_tutorial python notebook.