### PR TITLE
Force pybind11 version

### DIFF
--- a/symforce/pybind/CMakeLists.txt
+++ b/symforce/pybind/CMakeLists.txt
@@ -9,7 +9,7 @@
 
 include(FetchContent)
 
-find_package(pybind11 QUIET)
+find_package(pybind11 2.9.2 QUIET)
 if (NOT pybind11_FOUND)
   message(STATUS "pybind11 not found, adding with FetchContent")
   # NOTE(brad): Set PYTHON_EXECUTABLE to ensure pybind11 uses the same


### PR DESCRIPTION
Force cmake to find pybind11 version 2.9.2 to not conflict with older pybind versions installed by ros 2 galactic