### PR TITLE
Move to spdlog1.10.0 and its embedded fmt 8.1.1

### DIFF
--- a/symforce/opt/CMakeLists.txt
+++ b/symforce/opt/CMakeLists.txt
@@ -10,41 +10,18 @@
 include(FetchContent)
 
 # ------------------------------------------------------------------------------
-# fmtlib
-
-find_package(fmt 8...<9 QUIET)
-if (NOT fmt_FOUND)
-  message(STATUS "fmt not found, adding with FetchContent")
-  function(add_fmt)
-    set(FMT_INSTALL ON CACHE INTERNAL "fmt should create an install target")
-    FetchContent_Declare(
-      fmtlib
-      URL https://github.com/fmtlib/fmt/archive/8.0.1.zip
-      URL_HASH SHA256=6747442c189064b857336007dd7fa3aaf58512aa1a0b2ba76bf1182eefb01025
-    )
-    set(CMAKE_POSITION_INDEPENDENT_CODE True)
-    FetchContent_MakeAvailable(fmtlib)
-  endfunction()
-
-  add_fmt()
-else()
-  message(STATUS "fmt found")
-endif()
-
-# ------------------------------------------------------------------------------
 # spdlog
 
-find_package(spdlog 1.9.0 QUIET)
+find_package(spdlog 1.10.0 QUIET)
 if (NOT spdlog_FOUND)
   message(STATUS "spdlog not found, adding with FetchContent")
   function(add_spdlog)
     set(SPDLOG_INSTALL ON CACHE INTERNAL "spdlog should create an install target")
-    set(SPDLOG_FMT_EXTERNAL ON CACHE INTERNAL "spdlog shouldn't use its bundled fmtlib")
     set(CMAKE_POSITION_INDEPENDENT_CODE True)
     FetchContent_Declare(
       spdlog
-      URL https://github.com/gabime/spdlog/archive/v1.9.2.zip
-      URL_HASH SHA256=130bd593c33e2e2abba095b551db6a05f5e4a5a19c03ab31256c38fa218aa0a6
+      URL https://github.com/gabime/spdlog/archive/v1.10.0.zip
+      URL_HASH SHA256=7be28ff05d32a8a11cfba94381e820dd2842835f7f319f843993101bcab44b66
     )
     FetchContent_MakeAvailable(spdlog)
   endfunction()
@@ -124,7 +101,7 @@ add_library(
 )
 target_compile_options(symforce_cholesky PRIVATE ${SYMFORCE_COMPILE_OPTIONS})
 target_link_libraries(symforce_cholesky
-  fmt::fmt
+  spdlog::spdlog
   metis
   ${SYMFORCE_EIGEN_TARGET}
 )
@@ -145,7 +122,6 @@ target_compile_options(symforce_opt PRIVATE ${SYMFORCE_COMPILE_OPTIONS})
 target_link_libraries(symforce_opt
   symforce_gen
   symforce_cholesky
-  fmt::fmt
   spdlog::spdlog
   tl::optional
   ${SYMFORCE_EIGEN_TARGET}

--- a/symforce/opt/assert.h
+++ b/symforce/opt/assert.h
@@ -7,7 +7,10 @@
 
 #include <string>
 
-#include <fmt/format.h>
+#include <spdlog/spdlog.h>
+//
+#include <spdlog/fmt/fmt.h>
+//#include <spdlog/fmt/bundled/format.h>
 
 namespace sym {
 

--- a/symforce/opt/factor.cc
+++ b/symforce/opt/factor.cc
@@ -7,9 +7,11 @@
 
 #include <cassert>
 
-#include <fmt/format.h>
-#include <fmt/ostream.h>
-#include <fmt/ranges.h>
+#include <spdlog/spdlog.h>
+//
+#include <spdlog/fmt/bundled/format.h>
+#include <spdlog/fmt/bundled/ostream.h>
+#include <spdlog/fmt/bundled/ranges.h>
 
 #include "./assert.h"
 #include "./internal/factor_utils.h"

--- a/symforce/opt/internal/linearizer_utils.h
+++ b/symforce/opt/internal/linearizer_utils.h
@@ -9,8 +9,9 @@
 #include <utility>
 
 #include <Eigen/Sparse>
-#include <fmt/ranges.h>
 #include <spdlog/spdlog.h>
+//
+#include <spdlog/fmt/bundled/ranges.h>
 
 #include <lcmtypes/sym/linearization_dense_factor_helper_t.hpp>
 #include <lcmtypes/sym/linearization_sparse_factor_helper_t.hpp>

--- a/symforce/opt/internal/logging_configure.cc
+++ b/symforce/opt/internal/logging_configure.cc
@@ -7,8 +7,9 @@
 #include <cctype>
 #include <cstdlib>
 
-#include <fmt/ranges.h>
 #include <spdlog/spdlog.h>
+//
+#include <spdlog/fmt/bundled/ranges.h>
 
 namespace sym {
 namespace internal {

--- a/symforce/opt/internal/tic_toc.cc
+++ b/symforce/opt/internal/tic_toc.cc
@@ -5,9 +5,10 @@
 
 #include "./tic_toc.h"
 
-#include <fmt/format.h>
-#include <fmt/ostream.h>
 #include <spdlog/spdlog.h>
+//
+#include <spdlog/fmt/bundled/format.h>
+#include <spdlog/fmt/bundled/ostream.h>
 
 namespace sym {
 namespace internal {

--- a/symforce/opt/levenberg_marquardt_solver.tcc
+++ b/symforce/opt/levenberg_marquardt_solver.tcc
@@ -5,8 +5,9 @@
 
 #pragma once
 
-#include <fmt/ranges.h>
 #include <spdlog/spdlog.h>
+//
+#include <spdlog/fmt/bundled/ranges.h>
 
 #include "./levenberg_marquardt_solver.h"
 #include "./tic_toc.h"

--- a/symforce/opt/tic_toc.h
+++ b/symforce/opt/tic_toc.h
@@ -33,8 +33,8 @@
 #endif
 
 #else  // if !defined(SYMFORCE_TIC_TOC_HEADER)
-#include <fmt/format.h>
-#include <fmt/ostream.h>
+#include <spdlog/fmt/bundled/format.h>
+#include <spdlog/fmt/bundled/ostream.h>
 
 #include "./internal/tic_toc.h"
 

--- a/symforce/opt/values.cc
+++ b/symforce/opt/values.cc
@@ -5,8 +5,10 @@
 
 #include "./values.h"
 
-#include <fmt/format.h>
-#include <fmt/ostream.h>
+#include <spdlog/spdlog.h>
+//
+#include <spdlog/fmt/bundled/format.h>
+#include <spdlog/fmt/bundled/ostream.h>
 
 #include "./assert.h"
 

--- a/symforce/opt/values.tcc
+++ b/symforce/opt/values.tcc
@@ -7,8 +7,10 @@
 
 #include <stdexcept>
 
-#include <fmt/format.h>
-#include <fmt/ostream.h>
+#include <spdlog/spdlog.h>
+//
+#include <spdlog/fmt/bundled/format.h>
+#include <spdlog/fmt/bundled/ostream.h>
 
 #include "./assert.h"
 #include "./values.h"

--- a/symforce/pybind/cc_factor.cc
+++ b/symforce/pybind/cc_factor.cc
@@ -9,8 +9,12 @@
 #include <functional>
 
 #include <Eigen/Dense>
-#include <fmt/format.h>
-#include <fmt/ostream.h>
+#include <spdlog/spdlog.h>
+//
+#include <spdlog/fmt/bundled/format.h>
+#include <spdlog/fmt/bundled/ostream.h>
+//
+
 #include <pybind11/eigen.h>
 #include <pybind11/functional.h>
 #include <pybind11/pybind11.h>

--- a/symforce/pybind/cc_key.cc
+++ b/symforce/pybind/cc_key.cc
@@ -5,8 +5,10 @@
 
 #include "./cc_key.h"
 
-#include <fmt/format.h>
-#include <fmt/ostream.h>
+#include <spdlog/spdlog.h>
+//
+#include <spdlog/fmt/bundled/format.h>
+#include <spdlog/fmt/bundled/ostream.h>
 
 #include <symforce/opt/key.h>
 

--- a/symforce/pybind/cc_values.cc
+++ b/symforce/pybind/cc_values.cc
@@ -12,8 +12,11 @@
 #include <vector>
 
 #include <Eigen/Dense>
-#include <fmt/format.h>
-#include <fmt/ostream.h>
+#include <spdlog/spdlog.h>
+//
+#include <spdlog/fmt/bundled/format.h>
+#include <spdlog/fmt/bundled/ostream.h>
+//
 #include <pybind11/eigen.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>

--- a/symforce/pybind/lcm_type_casters.h
+++ b/symforce/pybind/lcm_type_casters.h
@@ -13,7 +13,10 @@
 
 #pragma once
 
-#include <fmt/format.h>
+#include <spdlog/spdlog.h>
+//
+#include <spdlog/fmt/bundled/format.h>
+//
 #include <pybind11/pybind11.h>
 
 #include <lcmtypes/sym/index_entry_t.hpp>

--- a/symforce/pybind/sym_type_casters.h
+++ b/symforce/pybind/sym_type_casters.h
@@ -13,7 +13,10 @@
 
 #pragma once
 
-#include <fmt/format.h>
+#include <spdlog/spdlog.h>
+//
+#include <spdlog/fmt/bundled/format.h>
+//
 #include <pybind11/pybind11.h>
 
 #include <sym/atan_camera_cal.h>

--- a/test/cam_function_codegen_cpp_test.cc
+++ b/test/cam_function_codegen_cpp_test.cc
@@ -17,9 +17,10 @@
 #include <Eigen/Dense>
 #include <catch2/catch_template_test_macros.hpp>
 #include <catch2/catch_test_macros.hpp>
-#include <fmt/ostream.h>
 #include <spdlog/spdlog.h>
-
+//
+#include <spdlog/fmt/bundled/ostream.h>
+//
 // TODO(nathan): We just test linear camera for now, but could/should test other types in the future
 #include <sym/linear_camera_cal.h>
 

--- a/test/cam_package_cpp_test.cc
+++ b/test/cam_package_cpp_test.cc
@@ -21,9 +21,10 @@
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/generators/catch_generators.hpp>
 #include <catch2/generators/catch_generators_range.hpp>
-#include <fmt/ostream.h>
 #include <spdlog/spdlog.h>
-
+//
+#include <spdlog/fmt/bundled/ostream.h>
+//
 #include <sym/atan_camera_cal.h>
 #include <sym/camera.h>
 #include <sym/double_sphere_camera_cal.h>

--- a/test/geo_package_cpp_test.cc
+++ b/test/geo_package_cpp_test.cc
@@ -20,8 +20,9 @@
 
 #include <catch2/catch_template_test_macros.hpp>
 #include <catch2/catch_test_macros.hpp>
-#include <fmt/ostream.h>
 #include <spdlog/spdlog.h>
+//
+#include <spdlog/fmt/bundled/ostream.h>
 
 #include <sym/pose2.h>
 #include <sym/pose3.h>

--- a/test/symforce_factor_test.cc
+++ b/test/symforce_factor_test.cc
@@ -10,8 +10,10 @@
 #include <catch2/catch_approx.hpp>
 #include <catch2/catch_template_test_macros.hpp>
 #include <catch2/catch_test_macros.hpp>
-#include <fmt/ostream.h>
 #include <spdlog/spdlog.h>
+//
+#include <spdlog/fmt/bundled/format.h>
+#include <spdlog/fmt/bundled/ostream.h>
 
 #include <lcmtypes/sym/index_entry_t.hpp>
 #include <lcmtypes/sym/linearized_dense_factor_t.hpp>

--- a/test/symforce_values_test.cc
+++ b/test/symforce_values_test.cc
@@ -8,8 +8,9 @@
 
 #include <catch2/catch_template_test_macros.hpp>
 #include <catch2/catch_test_macros.hpp>
-#include <fmt/ostream.h>
 #include <spdlog/spdlog.h>
+//
+#include <spdlog/fmt/bundled/ostream.h>
 
 #include <sym/atan_camera_cal.h>
 #include <sym/double_sphere_camera_cal.h>


### PR DESCRIPTION
We are having a large challenge integrating the particular version of spdlog and the external FMT that is downloaded n opt/CMakelists.txt. This version has a bundled fmt that works with the symforce codebase as is. The later spdlog 1.11.0 bumps embedded fmt to 9.x, which has some breaking changes, so this is the path of least friction for us and perhaps others.  Hopefully you agree.