### PR TITLE
Clarify error on failed symengine import

### DIFF
--- a/symforce/__init__.py
+++ b/symforce/__init__.py
@@ -116,7 +116,7 @@ def _find_symengine() -> ModuleType:
         if len(symengine_path_candidates) != 1:
             raise ImportError(
                 f"Should be exactly one symengine package, found candidates {symengine_path_candidates} in directory {path_util.symenginepy_install_dir()}"
-            )
+            ) from ex
         symengine_path = symengine_path_candidates[0]
 
         # Import symengine from the directory where we installed it.  See

--- a/symforce/__init__.py
+++ b/symforce/__init__.py
@@ -138,6 +138,7 @@ def _find_symengine() -> ModuleType:
 
         return symengine
 
+
 _symbolic_api: T.Optional[str] = None
 _have_imported_symbolic = False
 


### PR DESCRIPTION
It's much more common for the error you want here to be why symengine failed to import initially, and not that the manifest is missing, this should hopefully be more useful of an error message

Related: https://github.com/symforce-org/symforce/issues/336