### PR TITLE
Add `to_angle` for the `Rot2` class

### DIFF
--- a/symforce/geo/rot2.py
+++ b/symforce/geo/rot2.py
@@ -137,6 +137,14 @@ class Rot2(LieGroup):
         """
         return cls.from_tangent([theta])
 
+    def to_angle(self, epsilon=sf.epsilon()) -> T.Scalar:
+        """
+        Get the angle of this Rot2 in radians
+
+        This is equivalent to ``to_tangent()[0]``
+        """
+        return sf.atan2(self.z.imag, self.z.real, epsilon=epsilon)
+
     def to_rotation_matrix(self) -> Matrix22:
         """
         A matrix representation of this element in the Euclidean space that contains it.

--- a/symforce/geo/rot2.py
+++ b/symforce/geo/rot2.py
@@ -143,7 +143,7 @@ class Rot2(LieGroup):
 
         This is equivalent to ``to_tangent()[0]``
         """
-        return sf.atan2(self.z.imag, self.z.real, epsilon=epsilon)
+        return self.to_tangent(epsilon)[0]
 
     def to_rotation_matrix(self) -> Matrix22:
         """

--- a/symforce/geo/rot2.py
+++ b/symforce/geo/rot2.py
@@ -137,7 +137,7 @@ class Rot2(LieGroup):
         """
         return cls.from_tangent([theta])
 
-    def to_angle(self, epsilon=sf.epsilon()) -> T.Scalar:
+    def to_angle(self, epsilon: T.Scalar = sf.epsilon()) -> T.Scalar:
         """
         Get the angle of this Rot2 in radians
 

--- a/test/geo_rot2_test.py
+++ b/test/geo_rot2_test.py
@@ -49,6 +49,18 @@ class GeoRot2Test(LieGroupOpsTestMixin, TestCase):
         rot2 = sf.Rot2.from_tangent([1.5])
         self.assertEqual(rot1, rot2)
 
+    def test_from_to_angle(self) -> None:
+        """
+        Tests:
+            Rot2.from_angle
+            Rot2.to_angle
+        """
+        for angle, angle_gt in zip(
+                [0.0, np.pi / 2, np.pi, 3 * np.pi / 2, 2 * np.pi],
+                [0.0, np.pi / 2, np.pi, -np.pi / 2, 0.0]):
+            rot = sf.Rot2.from_angle(angle).evalf()
+            self.assertLess(abs(angle_gt - rot.to_angle()), 1e-8)
+
     def test_lie_exponential(self) -> None:
         """
         Tests:

--- a/test/geo_rot2_test.py
+++ b/test/geo_rot2_test.py
@@ -56,8 +56,9 @@ class GeoRot2Test(LieGroupOpsTestMixin, TestCase):
             Rot2.to_angle
         """
         for angle, angle_gt in zip(
-                [0.0, np.pi / 2, np.pi, 3 * np.pi / 2, 2 * np.pi],
-                [0.0, np.pi / 2, np.pi, -np.pi / 2, 0.0]):
+            [0.0, np.pi / 2, np.pi, 3 * np.pi / 2, 2 * np.pi],
+            [0.0, np.pi / 2, np.pi, -np.pi / 2, 0.0],
+        ):
             rot = sf.Rot2.from_angle(angle).evalf()
             self.assertLess(abs(angle_gt - rot.to_angle()), 1e-8)
 


### PR DESCRIPTION
I suggest adding a convenience function to get the angle from a 2D rotation. It complements the existing `from_angle`, and is intuitive to use when working with 2D rotation angles.