### PR TITLE
Remove Werror from CMakeLists

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,6 +120,7 @@ jobs:
           cmake -B build \
             -D CMAKE_C_COMPILER=${{ matrix.compiler.C }} \
             -D CMAKE_CXX_COMPILER=${{ matrix.compiler.CXX }} \
+            -D SYMFORCE_COMPILE_OPTIONS=-Wall;-Wextra;-Werror \
             -D SYMFORCE_PYTHON_OVERRIDE=${{ matrix.python }} \
             -D SYMFORCE_BUILD_BENCHMARKS=ON
           cmake --build build -j $(nproc)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,7 +120,7 @@ jobs:
           cmake -B build \
             -D CMAKE_C_COMPILER=${{ matrix.compiler.C }} \
             -D CMAKE_CXX_COMPILER=${{ matrix.compiler.CXX }} \
-            -D SYMFORCE_COMPILE_OPTIONS=-Wall;-Wextra;-Werror \
+            -D "SYMFORCE_COMPILE_OPTIONS=-Wall;-Wextra;-Werror" \
             -D SYMFORCE_PYTHON_OVERRIDE=${{ matrix.python }} \
             -D SYMFORCE_BUILD_BENCHMARKS=ON
           cmake --build build -j $(nproc)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,7 +74,7 @@ option(SYMFORCE_SKYMARSHAL_PRINTING
 
 option(SYMFORCE_BUILD_STATIC_LIBRARIES "Build libraries as static" OFF)
 
-set(SYMFORCE_COMPILE_OPTIONS -Wall;-Wextra;-Werror CACHE STRING
+set(SYMFORCE_COMPILE_OPTIONS -Wall;-Wextra CACHE STRING
   "Extra flags to pass to the compiler; defaults to enabling warnings"
 )
 

--- a/symforce/opt/optimizer.cc
+++ b/symforce/opt/optimizer.cc
@@ -20,6 +20,8 @@ sym::optimizer_params_t sym::DefaultOptimizerParams() {
   const double early_exit_min_reduction = 1e-6;
   const bool enable_bold_updates = false;
 
+  const bool something_unused;
+
   return sym::optimizer_params_t{
       verbose,
       initial_lambda,

--- a/symforce/opt/optimizer.cc
+++ b/symforce/opt/optimizer.cc
@@ -20,8 +20,6 @@ sym::optimizer_params_t sym::DefaultOptimizerParams() {
   const double early_exit_min_reduction = 1e-6;
   const bool enable_bold_updates = false;
 
-  const bool something_unused = false;
-
   return sym::optimizer_params_t{
       verbose,
       initial_lambda,

--- a/symforce/opt/optimizer.cc
+++ b/symforce/opt/optimizer.cc
@@ -20,7 +20,7 @@ sym::optimizer_params_t sym::DefaultOptimizerParams() {
   const double early_exit_min_reduction = 1e-6;
   const bool enable_bold_updates = false;
 
-  const bool something_unused;
+  const bool something_unused = false;
 
   return sym::optimizer_params_t{
       verbose,


### PR DESCRIPTION
Fixes #369 

Standard practice is to set `-Werror` in environments like CI so that it fails the build there, but not default it on for all builds, so that users have the best chance of building successfully on compilers not tested by CI that emit different warnings.

We should probably just turn off `-Wall` and `-Wextra` outside CI as well, and possibly get rid of `SYMFORCE_COMPILE_OPTIONS`, but I'm leaving that for now.