### PR TITLE
[SymForce] Bump action versions

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Build Wheels
       run: |
@@ -20,9 +20,9 @@ jobs:
         python3 -m build --sdist --wheel gen/python --outdir ./dist
 
     - name: Upload Wheels
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
-        name: symforce-wheels
+        name: symforce-wheels-extra
         path: dist/*
 
   build-macos:
@@ -36,7 +36,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Install cibuildwheel
       run: python3 -m pip install cibuildwheel==2.16.5
@@ -52,9 +52,9 @@ jobs:
         CIBW_ENVIRONMENT: SYMFORCE_REWRITE_LOCAL_DEPENDENCIES=True
 
     - name: Upload wheels
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
-        name: symforce-wheels
+        name: symforce-wheels-macos-${{ matrix.python-version }}-${{ matrix.arch }}
         path: wheelhouse/*.whl
 
   build-linux:
@@ -67,7 +67,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Install cibuildwheel
       run: python3 -m pip install cibuildwheel==2.16.5
@@ -81,7 +81,20 @@ jobs:
         CIBW_ENVIRONMENT: SYMFORCE_REWRITE_LOCAL_DEPENDENCIES=True
 
     - name: Upload Wheels
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
-        name: symforce-wheels
+        name: symforce-wheels-linux-${{ matrix.python-version }}
         path: wheelhouse/*.whl
+
+  merge-wheel-artifacts:
+    runs-on: ubuntu-latest
+    needs:
+      - build-extra
+      - build-macos
+      - build-linux
+    steps:
+      - uses: actions/upload-artifact/merge@v4
+        with:
+          name: symforce-wheels
+          pattern: wheelhouse/*.whl
+          delete-merged: true

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -96,5 +96,4 @@ jobs:
       - uses: actions/upload-artifact/merge@v4
         with:
           name: symforce-wheels
-          pattern: wheelhouse/*.whl
           delete-merged: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
               repos: []
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # - Installing software-properties-common adds add-apt-repository
       - name: Update install tools
@@ -157,7 +157,7 @@ jobs:
       # (probably any is good, assuming they all pass)
       # Unzip to a directory and run `npx http-server` in that directory
       - name: Upload Generated Docs
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: docs ${{ matrix.os }}-${{ matrix.python }}-${{ matrix.compiler.C }}
           path: build/docs

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install build dependencies
         run: |

--- a/.github/workflows/test_editable_pip_install.yml
+++ b/.github/workflows/test_editable_pip_install.yml
@@ -20,7 +20,7 @@ jobs:
         setuptools_version: [65.3.0]
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - if: ${{ matrix.os == 'macos-12' }}
         uses: actions/setup-python@v4


### PR DESCRIPTION
Resolves some deprecated stuff.  upload action is now per matrix entry,
async, which is cool for the docs, but means we merge afterwards for the
wheels

Topic: sf-actions-upgrade