### PR TITLE
Replaced space character

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ from setuptools.command.egg_info import egg_info
 from setuptools.command.install import install
 
 SOURCE_DIR = Path(__file__).resolve().parent
+SOURCE_DIR = str(SOURCE_DIR).replace(' ', '%20')
 
 
 def symforce_version() -> str:


### PR DESCRIPTION
### **Description**
As a workaround for **Issue #400**, I modified the `setup.py` to replace spaces in the `SOURCE_DIR` path with `%20`, which allowed the build process to proceed:

```python
SOURCE_DIR = str(SOURCE_DIR).replace(' ', '%20')
```

However, this is only a temporary fix, and the issue should ideally be resolved by properly escaping or quoting directory paths with spaces in the build scripts.