### PR TITLE
Publish automatically to PyPI

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -5,6 +5,8 @@ on:
     branches:
      - 'main'
      - 'skydio-export-master'
+    tags:
+     - 'v*.*.*'
   workflow_dispatch:
 
 jobs:
@@ -131,3 +133,33 @@ jobs:
         with:
           name: symforce-wheels
           delete-merged: true
+
+  # publish-to-pypi:
+  #   name: Publish Python 🐍 distribution 📦 to PyPI
+  #   strategy:
+  #     matrix:
+  #       package: [symforce, symforce_sym, skymarshal]
+  #   if: startsWith(github.ref, 'refs/tags/')  # only publish to PyPI on tag pushes
+  #   needs:
+  #   - merge-wheel-artifacts
+  #   runs-on: ubuntu-latest
+
+  #   environment:
+  #     name: testpypi
+  #     url: https://test.pypi.org/p/${{ matrix.package }}
+
+  #   permissions:
+  #     id-token: write
+
+  #   steps:
+  #   - name: Download all the dists
+  #     uses: actions/download-artifact@v4
+  #     with:
+  #       name: symforce-wheels
+  #       path: wheels-download/
+  #   - run: mkdir dist && cp wheels-download/${{ matrix.package }}-*.whl dist/
+  #   - name: Publish distribution 📦 to PyPI
+  #     uses: pypa/gh-action-pypi-publish@release/v1
+  #     with:
+  #       verbose: true
+  #       repository-url: https://test.pypi.org/legacy/

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -99,6 +99,12 @@ To set the symbolic API, you can either use :func:`symforce.set_symbolic_api()` 
 Building wheels
 *************************************************
 
+Wheels are built automatically for pushes to the main branch, by the ``build_wheels`` GitHub
+Actions workflow.  Previous runs of this workflow will have the built wheels available as an
+artifact.  The workflow can also be run manually on a branch.  All runs will have wheels available
+on the action as a ``symforce-wheels.zip`` artifact.  Tagged commits will also push to PyPI
+automatically.
+
 You should be able to build Python wheels of symforce the standard ways.  We recommend using
 ``build``, i.e. running ``python3 -m build --wheel`` from the ``symforce`` directory.  By default,
 this will build a wheel that includes local dependencies on the ``skymarshal`` and ``symforce-sym``
@@ -106,12 +112,6 @@ packages (which are separate Python packages from ``symforce`` itself).  For dis
 typically want to set the environment variable ``SYMFORCE_REWRITE_LOCAL_DEPENDENCIES`` to the
 release version when building, and also run ``python3 -m build --wheel third_party/skymarshal`` and
 ``python3 -m build --wheel gen/python`` to build wheels for those packages separately.
-
-For SymForce releases, all of this is handled by the ``build_wheels`` GitHub Actions workflow.  This
-workflow is currently run manually on a commit, and produces a ``symforce-wheels.zip`` artifact with
-wheels (and sdists) for distribution (e.g. on PyPI).  It doesn't upload them to PyPI - to do that
-(after verifying that the built wheels work as expected) you should download and unzip the archive,
-and upload to PyPI with ``python -m twine upload [--repository testpypi] --verbose *``.
 
 *************************************************
 Adding new types


### PR DESCRIPTION
Use the pypa-blessed github action to publish built wheels automatically
to PyPI:
https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/

Just following the instructions there, with modifications to handle our
three different packages.

This setup is much nicer in combination with automatic versioning; when
a tag is pushed (which will tell setuptools_scm that the symforce
version should be that tag), wheels are published to PyPI.

Topic: sf-auto-publish
Relative: sf-auto-version