### PR TITLE
Specify README Encoding in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -381,7 +381,7 @@ def fixed_readme() -> str:
     """
     Fix things in the README for PyPI
     """
-    readme = Path("README.md").read_text()
+    readme = Path("README.md").read_text(encoding='UTF8')
 
     # Replace relative links with absolute, so images appear correctly on PyPI
     readme = readme.replace(


### PR DESCRIPTION
This was causing setup to fail on a windows machine with a default encoding other than UTF8