### PR TITLE
Bump pybind

### DIFF
--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -225,7 +225,7 @@ ptyprocess==0.7.0
     # via pexpect
 pure-eval==0.2.2
     # via stack-data
-pybind11-stubgen==2.5.1
+pybind11-stubgen==2.5.3
     # via symforce (setup.py)
 pygments==2.18.0
     # via

--- a/setup.py
+++ b/setup.py
@@ -401,7 +401,8 @@ if __name__ == "__main__":
                     "numba",
                     # 6.13 fixes pip >=23.1 support
                     "pip-tools>=6.13",
-                    "pybind11-stubgen>=1.0",
+                    # For https://github.com/sizmailov/pybind11-stubgen/pull/243
+                    "pybind11-stubgen>=2.5.3",
                     # 0.7.2 introduces this bug: https://github.com/astral-sh/ruff/pull/15090
                     "ruff==0.7.1",
                     "types-jinja2",

--- a/symforce/pybind/CMakeLists.txt
+++ b/symforce/pybind/CMakeLists.txt
@@ -9,7 +9,7 @@
 
 include(FetchContent)
 
-find_package(pybind11 2.9.2 QUIET)
+find_package(pybind11 2.13.6 QUIET)
 if (NOT pybind11_FOUND)
   message(STATUS "pybind11 not found, adding with FetchContent")
   # NOTE(brad): Set PYTHON_EXECUTABLE to ensure pybind11 uses the same
@@ -17,8 +17,8 @@ if (NOT pybind11_FOUND)
   set(PYTHON_EXECUTABLE ${SYMFORCE_PYTHON})
   FetchContent_Declare(
     pybind11
-    URL https://github.com/pybind/pybind11/archive/v2.9.2.zip
-    URL_HASH SHA256=d1646e6f70d8a3acb2ddd85ce1ed543b5dd579c68b8fb8e9638282af20edead8
+    URL https://github.com/pybind/pybind11/archive/v2.13.6.zip
+    URL_HASH SHA256=d0a116e91f64a4a2d8fb7590c34242df92258a61ec644b79127951e821b47be6
   )
   FetchContent_MakeAvailable(pybind11)
 else()


### PR DESCRIPTION
Fixes #425

Our previous version of pybind didn't support py3.11.  pybind 2.13.6
supports all versions of python that we support.  There isn't much
downside to downloading an additional copy of pybind if you have an
older one installed that supports your version of python.  If we wanted
to we could write some table of minimum required versions based on
SYMFORCE_PYTHON's version

Topic: sf-pybind
Relative: fix-wheels