### PR TITLE
Fix wheel builds

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -14,7 +14,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         # Should include history since the last tag for setuptools_scm to work
-        fetch-depth: 200
+        fetch-depth: 300
         fetch-tags: true
 
     - name: Build Wheels
@@ -48,7 +48,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         # Should include history since the last tag for setuptools_scm to work
-        fetch-depth: 200
+        fetch-depth: 300
         fetch-tags: true
 
     - run: python3 -m pip install setuptools_scm
@@ -62,7 +62,6 @@ jobs:
         CIBW_BUILD_FRONTEND: build
         # For arm64; for x86, it's at /usr/local but cmake finds that ok already
         GMP_ROOT: /opt/homebrew
-        CIBW_BEFORE_BUILD: brew install gmp
         CIBW_ENVIRONMENT: SYMFORCE_REWRITE_LOCAL_DEPENDENCIES=$SYMFORCE_VERSION MACOSX_DEPLOYMENT_TARGET=13.0
 
     - name: Upload wheels
@@ -84,7 +83,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         # Should include history since the last tag for setuptools_scm to work
-        fetch-depth: 200
+        fetch-depth: 300
         fetch-tags: true
 
     - run: python3 -m pip install setuptools_scm


### PR DESCRIPTION
- Rewriting the egg info stopped working at some point.  I'm not sure
  when (they were still getting partly rewritten after the environment
  variable change so it wasn't that).  I can't think of a reason not to
  do it this way though, which is simpler.
- We're more than 300 commits away from the last tag
- Don't need to install gmp on macos, it's already installed.  Not
  a necessary change, just suppresses a warning

Topic: fix-wheels