### PR TITLE
Format string is not known at compile time

### DIFF
--- a/symforce/opt/assert.h
+++ b/symforce/opt/assert.h
@@ -26,7 +26,7 @@ template <typename... T>
 inline std::string FormatFailure(const char* error, const char* func, const char* file, int line,
                                  const char* fmt, T&&... args) {
   return fmt::format("SYM_ASSERT: {}\n    --> {}\n    --> {}:{}\n{}\n", error, func, file, line,
-                     fmt::format(fmt, std::forward<T>(args)...));
+                     fmt::format(fmt::runtime(fmt), std::forward<T>(args)...));
 }
 
 }  // namespace sym


### PR DESCRIPTION
Liking to the project with g++-13 does not work, as it has stronger enforcement on constexpr rules. 

The offender was a string passed to `fmt::format` that is not known at compile time, so I wrap it in `fmt::runtime`.

Now links fine with g++-13.