### PR TITLE
fix fmt::format for c++20

### DIFF
--- a/symforce/opt/assert.h
+++ b/symforce/opt/assert.h
@@ -25,8 +25,9 @@ inline std::string FormatFailure(const char* error, const char* func, const char
 template <typename... T>
 inline std::string FormatFailure(const char* error, const char* func, const char* file, int line,
                                  const char* fmt, T&&... args) {
-  return fmt::format("SYM_ASSERT: {}\n    --> {}\n    --> {}:{}\n{}\n", error, func, file, line,
-                     fmt::format(fmt, std::forward<T>(args)...));
+  return fmt::format("SYM_ASSERT: {}\n    --> {}\n    --> {}:{}\n{}\n",
+                     error, func, file, line,
+                     fmt::format(fmt::runtime(fmt), std::forward<T>(args)...));
 }
 
 }  // namespace sym

--- a/symforce/opt/internal/tic_toc.cc
+++ b/symforce/opt/internal/tic_toc.cc
@@ -143,7 +143,7 @@ void TicTocManager::PrintTimingResults(std::ostream& out) const {
     separator += std::string("+") + std::string(16, '-');
   }
 
-  const std::string legend = fmt::format(header_fmt, "   Name", "Count", "Total Time (s)",
+  const std::string legend = fmt::format(fmt::runtime(header_fmt), "   Name", "Count", "Total Time (s)",
                                          "Mean Time (s)", "Max Time (s)", "Min Time (s)");
 
   fmt::print(out, "\nSymForce TicToc Results:\n");


### PR DESCRIPTION
I have created a simple fix to enable symforce compilation for c++20 by wrapping the runtime string into `fmt::runtime`. 

There is one downside though: we lose compile-time format-string checking for some assert-message payloads.
