### PR TITLE
Use system fmt, spdlog and metis in symforce opt (requires C++20).

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,8 +9,9 @@ cmake_minimum_required(VERSION 3.19...4.0)
 
 project(symforce)
 
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
 # ==============================================================================
 # User-Configurable Options

--- a/cmake/FindMETIS.cmake
+++ b/cmake/FindMETIS.cmake
@@ -1,0 +1,110 @@
+#
+# Copyright (c) 2022 Sergiu Deitsch
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTMETISLAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+#[=======================================================================[.rst:
+Module for locating METIS
+=========================
+
+Read-only variables:
+
+``METIS_FOUND``
+  Indicates whether the library has been found.
+
+``METIS_VERSION``
+  Indicates library version.
+
+Targets
+-------
+
+``METIS::METIS``
+  Specifies targets that should be passed to target_link_libararies.
+]=======================================================================]
+
+include (FindPackageHandleStandardArgs)
+
+find_path (METIS_INCLUDE_DIR NAMES metis.h
+  PATH_SUFFIXES include
+  DOC "METIS include directory")
+find_library (METIS_LIBRARY_DEBUG NAMES metis
+  PATH_SUFFIXES Debug
+  DOC "METIS debug library")
+find_library (METIS_LIBRARY_RELEASE NAMES metis
+  PATH_SUFFIXES Release
+  DOC "METIS release library")
+
+if (METIS_LIBRARY_RELEASE)
+  if (METIS_LIBRARY_DEBUG)
+    set (METIS_LIBRARY debug ${METIS_LIBRARY_DEBUG} optimized
+      ${METIS_LIBRARY_RELEASE} CACHE STRING "METIS library")
+  else (METIS_LIBRARY_DEBUG)
+    set (METIS_LIBRARY ${METIS_LIBRARY_RELEASE} CACHE FILEPATH "METIS library")
+  endif (METIS_LIBRARY_DEBUG)
+elseif (METIS_LIBRARY_DEBUG)
+  set (METIS_LIBRARY ${METIS_LIBRARY_DEBUG} CACHE FILEPATH "METIS library")
+endif (METIS_LIBRARY_RELEASE)
+
+set (_METIS_VERSION_HEADER ${METIS_INCLUDE_DIR}/metis.h)
+
+if (EXISTS ${_METIS_VERSION_HEADER})
+  file (READ ${_METIS_VERSION_HEADER} _METIS_VERSION_CONTENTS)
+
+  string (REGEX REPLACE ".*#define METIS_VER_MAJOR[ \t]+([0-9]+).*" "\\1"
+    METIS_VERSION_MAJOR "${_METIS_VERSION_CONTENTS}")
+  string (REGEX REPLACE ".*#define METIS_VER_MINOR[ \t]+([0-9]+).*" "\\1"
+    METIS_VERSION_MINOR "${_METIS_VERSION_CONTENTS}")
+  string (REGEX REPLACE ".*#define METIS_VER_SUBMINOR[ \t]+([0-9]+).*" "\\1"
+    METIS_VERSION_PATCH "${_METIS_VERSION_CONTENTS}")
+
+  set (METIS_VERSION
+    ${METIS_VERSION_MAJOR}.${METIS_VERSION_MINOR}.${METIS_VERSION_PATCH})
+  set (METIS_VERSION_COMPONENTS 3)
+endif (EXISTS ${_METIS_VERSION_HEADER})
+
+mark_as_advanced (METIS_INCLUDE_DIR METIS_LIBRARY_DEBUG METIS_LIBRARY_RELEASE
+  METIS_LIBRARY)
+
+if (NOT TARGET METIS::METIS)
+  if (METIS_INCLUDE_DIR OR METIS_LIBRARY)
+    add_library (METIS::METIS IMPORTED UNKNOWN)
+  endif (METIS_INCLUDE_DIR OR METIS_LIBRARY)
+endif (NOT TARGET METIS::METIS)
+
+if (METIS_INCLUDE_DIR)
+  set_property (TARGET METIS::METIS PROPERTY INTERFACE_INCLUDE_DIRECTORIES
+    ${METIS_INCLUDE_DIR})
+endif (METIS_INCLUDE_DIR)
+
+if (METIS_LIBRARY_RELEASE)
+  set_property (TARGET METIS::METIS PROPERTY IMPORTED_LOCATION_RELEASE
+    ${METIS_LIBRARY_RELEASE})
+  set_property (TARGET METIS::METIS APPEND PROPERTY IMPORTED_CONFIGURATIONS
+    RELEASE)
+endif (METIS_LIBRARY_RELEASE)
+
+if (METIS_LIBRARY_DEBUG)
+  set_property (TARGET METIS::METIS PROPERTY IMPORTED_LOCATION_DEBUG
+    ${METIS_LIBRARY_DEBUG})
+  set_property (TARGET METIS::METIS APPEND PROPERTY IMPORTED_CONFIGURATIONS
+    DEBUG)
+endif (METIS_LIBRARY_DEBUG)
+
+find_package_handle_standard_args (METIS REQUIRED_VARS
+  METIS_INCLUDE_DIR METIS_LIBRARY VERSION_VAR METIS_VERSION)

--- a/symforce/opt/CMakeLists.txt
+++ b/symforce/opt/CMakeLists.txt
@@ -10,86 +10,9 @@
 include(FetchContent)
 
 # ------------------------------------------------------------------------------
-# fmtlib
-
-find_package(fmt 8...<9 QUIET)
-if (NOT fmt_FOUND)
-  message(STATUS "fmt not found, adding with FetchContent")
-  function(add_fmt)
-    set(FMT_INSTALL ON CACHE INTERNAL "fmt should create an install target")
-    FetchContent_Declare(
-      fmtlib
-      URL https://github.com/fmtlib/fmt/archive/8.0.1.zip
-      URL_HASH SHA256=6747442c189064b857336007dd7fa3aaf58512aa1a0b2ba76bf1182eefb01025
-    )
-    set(CMAKE_POSITION_INDEPENDENT_CODE True)
-    FetchContent_MakeAvailable(fmtlib)
-  endfunction()
-
-  add_fmt()
-else()
-  message(STATUS "fmt found: ${fmt_VERSION}")
-endif()
-
-# ------------------------------------------------------------------------------
-# spdlog
-
-find_package(spdlog 1.9...<1.11 QUIET)
-if (NOT spdlog_FOUND)
-  message(STATUS "spdlog not found, adding with FetchContent")
-  function(add_spdlog)
-    set(SPDLOG_INSTALL ON CACHE INTERNAL "spdlog should create an install target")
-    set(SPDLOG_FMT_EXTERNAL ON CACHE INTERNAL "spdlog shouldn't use its bundled fmtlib")
-    set(CMAKE_POSITION_INDEPENDENT_CODE True)
-    FetchContent_Declare(
-      spdlog
-      URL https://github.com/gabime/spdlog/archive/v1.9.2.zip
-      URL_HASH SHA256=130bd593c33e2e2abba095b551db6a05f5e4a5a19c03ab31256c38fa218aa0a6
-    )
-    FetchContent_MakeAvailable(spdlog)
-  endfunction()
-
-  add_spdlog()
-else()
-  message(STATUS "spdlog found: ${spdlog_VERSION}")
-endif()
-
-# ------------------------------------------------------------------------------
-# METIS
-
-function(add_metis)
-  set(CMAKE_POSITION_INDEPENDENT_CODE True)
-  # CMake 4.0 removed compatibility with CMake 3.5: https://cmake.org/cmake/help/v4.0/release/4.0.html#deprecated-and-removed-features
-  # See the note below on METIS versioning; newest GKlib at https://github.com/KarypisLab/GKlib does
-  # support newer CMake, but we'd need to make sure the memory bugs mentioned below are resolved to
-  # upgrade.  The current copy of GKlib only declares it supports CMake 2.8.
-  set(CMAKE_POLICY_VERSION_MINIMUM 3.5)
-  FetchContent_Declare(
-    metis
-    # METIS does not have releases recently.  Previously were using nearly the initial commit on
-    # github, which is newer than the release on the METIS website. All of the releases on github
-    # seem to have memory bugs, which do not appear in this release:
-    URL https://symforce-org.github.io/downloads/metis-5.1.0.tar.gz
-    URL_HASH SHA256=76faebe03f6c963127dbb73c13eab58c9a3faeae48779f049066a21c087c5db2
-    # GKlib builds some test executables we can't disable without patching
-    PATCH_COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/../../cmake/patch_metis.sh" "${FETCHCONTENT_BASE_DIR}/metis-src"
-  )
-
-  # Tell metis where to find GKlib
-  set(GKLIB_PATH
-    "${FETCHCONTENT_BASE_DIR}/metis-src/GKlib" CACHE PATH "Path to GKlib for METIS" FORCE
-  )
-
-  set(METIS_LIBRARY_TYPE "SHARED" CACHE STRING "Always build METIS as a shared library" FORCE)
-
-  FetchContent_MakeAvailable(metis)
-
-  # Metis doesn't put its main header (metis.h) on the metis target
-  FetchContent_GetProperties(metis SOURCE_DIR metis_SOURCE_DIR)
-  target_include_directories(metis INTERFACE ${metis_SOURCE_DIR}/include)
-endfunction()
-
-add_metis()
+find_package(fmt REQUIRED)
+find_package(spdlog REQUIRED)
+find_package(metis REQUIRED)
 
 # ==============================================================================
 # SymForce Targets
@@ -109,7 +32,7 @@ add_library(
 target_compile_options(symforce_cholesky PRIVATE ${SYMFORCE_COMPILE_OPTIONS})
 target_link_libraries(symforce_cholesky
   fmt::fmt
-  metis
+  METIS::METIS
   ${SYMFORCE_EIGEN_TARGET}
 )
 target_include_directories(symforce_cholesky PUBLIC ../..)

--- a/symforce/opt/assert.h
+++ b/symforce/opt/assert.h
@@ -9,6 +9,8 @@
 
 #include <fmt/format.h>
 
+#include "./fmt_compat.h"
+
 namespace sym {
 
 /**

--- a/symforce/opt/dense_linearizer.cc
+++ b/symforce/opt/dense_linearizer.cc
@@ -7,6 +7,7 @@
 
 #include <tuple>
 
+#include "./fmt_compat.h"
 #include "./internal/linearizer_utils.h"
 
 namespace sym {

--- a/symforce/opt/dump_graph.h
+++ b/symforce/opt/dump_graph.h
@@ -11,6 +11,7 @@
 #include <fmt/format.h>
 
 #include "./factor.h"
+#include "./fmt_compat.h"
 #include "./key.h"
 
 namespace sym {

--- a/symforce/opt/factor.cc
+++ b/symforce/opt/factor.cc
@@ -10,6 +10,7 @@
 #include <fmt/ranges.h>
 
 #include "./assert.h"
+#include "./fmt_compat.h"
 #include "./internal/factor_utils.h"
 
 namespace sym {

--- a/symforce/opt/fmt_compat.h
+++ b/symforce/opt/fmt_compat.h
@@ -1,0 +1,57 @@
+/* ----------------------------------------------------------------------------
+ * fmt 11.x compatibility header for symforce
+ *
+ * fmt >= 11 no longer auto-discovers operator<< for formatting.  This header
+ * restores that behaviour for every class type that provides operator<< but
+ * is not already handled by fmt (strings, arithmetic, …).
+ *
+ * Two C++20 concepts do all the work:
+ *
+ *  1. EigenDerived  – disables fmt/ranges.h's range formatter for Eigen
+ *     expression types (Eigen 3.4+ exposes begin()/end()).
+ *
+ *  2. The formatter partial specialization – a single, universal catch-all
+ *     that delegates to fmt::ostream_formatter for any remaining class type
+ *     with operator<<.
+ * ---------------------------------------------------------------------------- */
+
+#pragma once
+
+#include <concepts>
+#include <ostream>
+#include <type_traits>
+
+#include <Eigen/Core>
+#include <Eigen/SparseCore>
+#include <fmt/ostream.h>
+#include <fmt/ranges.h>
+
+// ---------------------------------------------------------------------------
+// 1.  Disable fmt's range formatter for Eigen types.
+//
+//     Eigen 3.4+ types expose begin()/end() which makes fmt/ranges.h treat
+//     them as iterable ranges.  We want the human-readable matrix output from
+//     operator<< instead, so we mark them as range_format::disabled.
+// ---------------------------------------------------------------------------
+template <typename T>
+concept EigenDerived = requires(const T& t) { t.derived(); };
+
+template <EigenDerived T>
+struct fmt::range_format_kind<T, char>
+    : std::integral_constant<fmt::range_format, fmt::range_format::disabled> {};
+
+// ---------------------------------------------------------------------------
+// 2.  Universal ostream-based formatter for class types with operator<<.
+//
+//     Guards:
+//       • std::is_class_v           – excludes arithmetic, pointers, enums
+//                                     that fmt already handles natively.
+//       • !convertible to string_view – excludes std::string / string_view
+//                                     which have their own fmt formatter.
+//       • requires { os << t; }     – the type must actually support operator<<.
+// ---------------------------------------------------------------------------
+template <typename T>
+  requires std::is_class_v<T>
+        && (!std::is_convertible_v<const T&, fmt::string_view>)
+        && requires(std::ostream& os, const T& t) { os << t; }
+struct fmt::formatter<T, char> : fmt::ostream_formatter {};

--- a/symforce/opt/internal/derivative_checker.h
+++ b/symforce/opt/internal/derivative_checker.h
@@ -5,6 +5,8 @@
 
 #include <spdlog/spdlog.h>
 
+#include "../fmt_compat.h"
+
 #include "../util.h"
 #include "../values.h"
 

--- a/symforce/opt/internal/linearizer_utils.h
+++ b/symforce/opt/internal/linearizer_utils.h
@@ -13,6 +13,8 @@
 #include <fmt/ranges.h>
 #include <spdlog/spdlog.h>
 
+#include "../fmt_compat.h"
+
 #include <lcmtypes/sym/linearization_dense_factor_helper_t.hpp>
 #include <lcmtypes/sym/linearization_sparse_factor_helper_t.hpp>
 

--- a/symforce/opt/internal/optimizer_utils.h
+++ b/symforce/opt/internal/optimizer_utils.h
@@ -7,6 +7,7 @@
 
 #include <spdlog/spdlog.h>
 
+#include "../fmt_compat.h"
 #include "../optimization_stats.h"
 #include "../tic_toc.h"
 

--- a/symforce/opt/internal/tic_toc.cc
+++ b/symforce/opt/internal/tic_toc.cc
@@ -148,11 +148,11 @@ void TicTocManager::PrintTimingResults(std::ostream& out) const {
                   "Max Time (s)", "Min Time (s)");
 
   fmt::print(out, "\nSymForce TicToc Results:\n");
-  fmt::print(out, legend);
-  fmt::print(out, separator + "\n");
+  fmt::print(out, "{}", legend);
+  fmt::print(out, "{}\n", separator);
 
   for (const auto& [name, block] : blocks) {
-    fmt::print(out, output_fmt, name, block.Count(), float(block.TotalTime()),
+    fmt::print(out, fmt::runtime(output_fmt), name, block.Count(), float(block.TotalTime()),
                float(block.AverageTime()), float(block.MaxTime()), float(block.MinTime()));
   }
 }

--- a/symforce/opt/levenberg_marquardt_solver.tcc
+++ b/symforce/opt/levenberg_marquardt_solver.tcc
@@ -8,6 +8,8 @@
 #include <fmt/ranges.h>
 #include <spdlog/spdlog.h>
 
+#include "./fmt_compat.h"
+
 #include "./assert.h"
 #include "./levenberg_marquardt_solver.h"
 #include "./tic_toc.h"

--- a/symforce/opt/linearizer.cc
+++ b/symforce/opt/linearizer.cc
@@ -8,6 +8,7 @@
 #include <optional>
 
 #include "./assert.h"
+#include "./fmt_compat.h"
 #include "./internal/linearizer_utils.h"
 #include "./tic_toc.h"
 #include "symforce/opt/factor.h"

--- a/symforce/opt/util.h
+++ b/symforce/opt/util.h
@@ -100,7 +100,7 @@ auto NumericalDerivative(const F f, const X& x,
                              kDefaultEpsilon<typename StorageOps<X>::Scalar>,
                          const typename sym::StorageOps<X>::Scalar delta = 1e-2f) {
   using Scalar = typename sym::StorageOps<X>::Scalar;
-  using Y = typename std::result_of_t<F(X)>;
+  using Y = typename std::invoke_result_t<F, X>;
   using JacobianMat =
       Eigen::Matrix<Scalar, sym::LieGroupOps<Y>::TangentDim(), sym::LieGroupOps<X>::TangentDim()>;
   static_assert(std::is_same<typename sym::StorageOps<Y>::Scalar, Scalar>::value,

--- a/symforce/opt/values.cc
+++ b/symforce/opt/values.cc
@@ -8,6 +8,8 @@
 #include <fmt/format.h>
 #include <fmt/ostream.h>
 
+#include "./fmt_compat.h"
+
 #include "./assert.h"
 
 namespace sym {

--- a/symforce/opt/values.tcc
+++ b/symforce/opt/values.tcc
@@ -10,6 +10,8 @@
 #include <fmt/format.h>
 #include <fmt/ostream.h>
 
+#include "./fmt_compat.h"
+
 #include "./assert.h"
 #include "./values.h"
 


### PR DESCRIPTION
Symforce require old version of fmt lib (8.X), because the opt module use fmt to print Eigen derived objects. So it manually download and also install fmt spdlog and metis into the install directory. 
This causes obvious issue when try to use latest ROS2 version, becaue many library already requires fmtlib >9.0 (latest is 11.x). 

The reason for the requirement of fmtlib 8.x is because fmt automatically support object with `operator <<` operation at that time. But this brokes after fmtlib 9.0.

Previous to c++20, this is almost impossible to fix (or at least with many tedious work, in fact claude opus gives me a dirty fix), see https://github.com/fmtlib/fmt/issues/3465#issuecomment-1573078226.
But if we advance the cxx standard to c++20, there is a beautiful fix with concept `requires(std::ostream& os, const T& t) { os << t; }`
The actual fix is below

```
// ---------------------------------------------------------------------------
// 2.  Universal ostream-based formatter for class types with operator<<.
//
//     Guards:
//       • std::is_class_v           – excludes arithmetic, pointers, enums
//                                     that fmt already handles natively.
//       • !convertible to string_view – excludes std::string / string_view
//                                     which have their own fmt formatter.
//       • requires { os << t; }     – the type must actually support operator<<.
// ---------------------------------------------------------------------------
template <typename T>
  requires std::is_class_v<T>
        && (!std::is_convertible_v<const T&, fmt::string_view>)
        && requires(std::ostream& os, const T& t) { os << t; }
struct fmt::formatter<T, char> : fmt::ostream_formatter {};
```
