### PR TITLE
[Caspar] Replace legacy FindCUDA with modern CMake CUDA language support + minor compile function improvements

### DIFF
--- a/symforce/caspar/code_generation/library.py
+++ b/symforce/caspar/code_generation/library.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import logging
 import shutil
+import subprocess
 from pathlib import Path
 
 from symforce import caspar
@@ -147,17 +148,24 @@ class CasparLibrary:
         self.generate_kernels(out_dir)
 
     @staticmethod
-    def compile(out_dir: Path, debug: bool = False) -> None:
-        import subprocess
-
+    def compile(
+        out_dir: Path,
+        debug: bool = False,
+        cuda_architectures: str | None = None,
+        jobs: int | None = None,
+    ) -> None:
         build_dir = out_dir / "build"
         build_dir.mkdir(exist_ok=True)
         logging.info(f"Compiling {out_dir}")
-        if debug:
-            subprocess.run(["cmake", "-DCMAKE_BUILD_TYPE=Debug", ".."], cwd=build_dir, check=True)
-        else:
-            subprocess.run(["cmake", "-DCMAKE_BUILD_TYPE=Release", ".."], cwd=build_dir, check=True)
-        subprocess.run(["make", "-j"], cwd=build_dir, check=True)
+        cmake_args = ["cmake", f"-DCMAKE_BUILD_TYPE={'Debug' if debug else 'Release'}"]
+        if cuda_architectures is not None:
+            cmake_args.append(f"-DCMAKE_CUDA_ARCHITECTURES={cuda_architectures}")
+        cmake_args.append("..")
+        subprocess.run(cmake_args, cwd=build_dir, check=True)
+        build_args = ["cmake", "--build", "."]
+        if jobs is not None:
+            build_args += ["--parallel", str(jobs)]
+        subprocess.run(build_args, cwd=build_dir, check=True)
 
     # This function has no annotated return type, so that type inference in IDEs can get more
     # specific typing than ModuleType

--- a/symforce/caspar/code_generation/library.py
+++ b/symforce/caspar/code_generation/library.py
@@ -49,6 +49,25 @@ def insert_sorted_unique(
             container.insert(lo, item)
 
 
+def _real_cuda_arch_string() -> str:
+    """Return a CMake CUDA_ARCHITECTURES string with SASS-only targets for all detected GPUs.
+
+    Using -real (no PTX embedding) avoids cudaErrorUnsupportedPtxVersion when the nvcc version
+    exceeds the installed CUDA driver version.
+    """
+    try:
+        out = subprocess.run(
+            ["nvidia-smi", "--query-gpu=compute_cap", "--format=csv,noheader"],
+            capture_output=True, text=True, check=True, timeout=10,
+        ).stdout
+        caps = sorted({cap.replace(".", "") for cap in out.strip().splitlines() if cap.strip()})
+        if caps:
+            return ";".join(f"{cap}-real" for cap in caps)
+    except Exception:
+        pass
+    return "native"
+
+
 class CasparLibrary:
     """
     The CasLib class is the main entry point for generating and compiling caspar libraries.
@@ -151,21 +170,20 @@ class CasparLibrary:
     def compile(
         out_dir: Path,
         debug: bool = False,
-        cuda_architectures: str | None = None,
+        cuda_arch: str | None = None,
         jobs: int | None = None,
     ) -> None:
         build_dir = out_dir / "build"
-        build_dir.mkdir(exist_ok=True)
-        logging.info(f"Compiling {out_dir}")
-        cmake_args = ["cmake", f"-DCMAKE_BUILD_TYPE={'Debug' if debug else 'Release'}"]
-        if cuda_architectures is not None:
-            cmake_args.append(f"-DCMAKE_CUDA_ARCHITECTURES={cuda_architectures}")
-        cmake_args.append("..")
-        subprocess.run(cmake_args, cwd=build_dir, check=True)
-        build_args = ["cmake", "--build", "."]
-        if jobs is not None:
-            build_args += ["--parallel", str(jobs)]
-        subprocess.run(build_args, cwd=build_dir, check=True)
+        config_cmd = [
+            "cmake", "-S", out_dir, "-B", build_dir,
+            f"-DCMAKE_BUILD_TYPE={'Debug' if debug else 'Release'}",
+            f"-DCMAKE_CUDA_ARCHITECTURES={cuda_arch if cuda_arch is not None else _real_cuda_arch_string()}",
+        ]
+        subprocess.run(config_cmd, check=True)
+        build_cmd = ["cmake", "--build", build_dir, "--parallel"]
+        if jobs:
+            build_cmd.append(str(jobs))
+        subprocess.run(build_cmd, check=True)
 
     # This function has no annotated return type, so that type inference in IDEs can get more
     # specific typing than ModuleType

--- a/symforce/caspar/source/templates/buildfiles/CMakeLists.txt.jinja
+++ b/symforce/caspar/source/templates/buildfiles/CMakeLists.txt.jinja
@@ -17,19 +17,23 @@ endif()
 
 find_package(CUDAToolkit REQUIRED)
 
-include(FetchContent)
-find_package(pybind11 2.13.6 QUIET)
-if(NOT pybind11_FOUND)
-  message(STATUS "pybind11 not found, adding with FetchContent")
-  FetchContent_Declare(
-    pybind11
-    URL https://github.com/pybind/pybind11/archive/v2.13.6.zip
-    URL_HASH SHA256=d0a116e91f64a4a2d8fb7590c34242df92258a61ec644b79127951e821b47be6
-    DOWNLOAD_EXTRACT_TIMESTAMP TRUE
-  )
-  FetchContent_MakeAvailable(pybind11)
-else()
-  message(STATUS "pybind11 found")
+option(CASPAR_BUILD_PYTHON_BINDINGS "Build Python bindings via pybind11" ON)
+
+if(CASPAR_BUILD_PYTHON_BINDINGS)
+  include(FetchContent)
+  find_package(pybind11 2.13.6 QUIET)
+  if(NOT pybind11_FOUND)
+    message(STATUS "pybind11 not found, adding with FetchContent")
+    FetchContent_Declare(
+      pybind11
+      URL https://github.com/pybind/pybind11/archive/v2.13.6.zip
+      URL_HASH SHA256=d0a116e91f64a4a2d8fb7590c34242df92258a61ec644b79127951e821b47be6
+      DOWNLOAD_EXTRACT_TIMESTAMP TRUE
+    )
+    FetchContent_MakeAvailable(pybind11)
+  else()
+    message(STATUS "pybind11 found")
+  endif()
 endif()
 
 file(GLOB CUDA_SOURCES RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} "*.cu" "*.cc")
@@ -47,13 +51,14 @@ set_target_properties({{caslib.name}}_core PROPERTIES
   POSITION_INDEPENDENT_CODE ON
 )
 
-file(GLOB CPP_SOURCES "pybind*.cc")
-file(GLOB CPP_HEADERS "*.h")
+if(CASPAR_BUILD_PYTHON_BINDINGS)
+  file(GLOB CPP_SOURCES "pybind*.cc")
 
-pybind11_add_module({{caslib.name}} ${CPP_SOURCES} ${CPP_HEADERS})
-target_link_libraries({{caslib.name}} PRIVATE {{caslib.name}}_core)
+  pybind11_add_module({{caslib.name}} ${CPP_SOURCES})
+  target_link_libraries({{caslib.name}} PRIVATE {{caslib.name}}_core)
 
-set_target_properties({{caslib.name}} PROPERTIES
-  LIBRARY_OUTPUT_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-  RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-)
+  set_target_properties({{caslib.name}} PROPERTIES
+    LIBRARY_OUTPUT_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+  )
+endif()

--- a/symforce/caspar/source/templates/buildfiles/CMakeLists.txt.jinja
+++ b/symforce/caspar/source/templates/buildfiles/CMakeLists.txt.jinja
@@ -19,6 +19,8 @@ if(NOT DEFINED CMAKE_CUDA_ARCHITECTURES)
   endif()
 endif()
 
+find_package(CUDAToolkit REQUIRED)
+
 include(FetchContent)
 find_package(pybind11 2.13.6 QUIET)
 if(NOT pybind11_FOUND)
@@ -41,6 +43,7 @@ list(FILTER CUDA_HEADERS EXCLUDE REGEX "pybind.*")
 
 add_library({{caslib.name}}_core STATIC ${CUDA_SOURCES} ${CUDA_HEADERS})
 target_include_directories({{caslib.name}}_core PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+target_link_libraries({{caslib.name}}_core PUBLIC CUDA::cudart)
 target_compile_options({{caslib.name}}_core PRIVATE
   $<$<COMPILE_LANGUAGE:CUDA>:--use_fast_math>
 )

--- a/symforce/caspar/source/templates/buildfiles/CMakeLists.txt.jinja
+++ b/symforce/caspar/source/templates/buildfiles/CMakeLists.txt.jinja
@@ -2,39 +2,50 @@
  # SymForce - Copyright 2025, Skydio, Inc.
  # This source code is under the Apache 2.0 license found in the LICENSE file.
  # ---------------------------------------------------------------------------- #}
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.18)
 
-project(caspar_library LANGUAGES CXX)
-set(CUDA_TOOLKIT_ROOT_DIR /usr/local/cuda)
+if(NOT DEFINED CMAKE_CUDA_COMPILER AND DEFINED ENV{CUDACXX})
+  set(CMAKE_CUDA_COMPILER "$ENV{CUDACXX}" CACHE FILEPATH "CUDA compiler")
+endif()
 
-find_package(CUDA REQUIRED)
+project(caspar_library LANGUAGES CXX CUDA)
+
+# SASS for Turing/Ampere/Ada (sm_75–89) + PTX fallback for forward JIT-compatibility. sm_75 minimum required by cooperative_groups::reduce.
+if(NOT DEFINED CMAKE_CUDA_ARCHITECTURES)
+  if(CMAKE_VERSION VERSION_GREATER_EQUAL "3.24")
+    set(CMAKE_CUDA_ARCHITECTURES native)
+  else()
+    set(CMAKE_CUDA_ARCHITECTURES 75 80 86 89 75-virtual)
+  endif()
+endif()
+
 include(FetchContent)
 find_package(pybind11 2.13.6 QUIET)
-if (NOT pybind11_FOUND)
+if(NOT pybind11_FOUND)
   message(STATUS "pybind11 not found, adding with FetchContent")
   FetchContent_Declare(
     pybind11
     URL https://github.com/pybind/pybind11/archive/v2.13.6.zip
     URL_HASH SHA256=d0a116e91f64a4a2d8fb7590c34242df92258a61ec644b79127951e821b47be6
+    DOWNLOAD_EXTRACT_TIMESTAMP TRUE
   )
   FetchContent_MakeAvailable(pybind11)
 else()
   message(STATUS "pybind11 found")
 endif()
 
-set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS} --use_fast_math -arch=sm_75")
-set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS} -Xcompiler -fPIC")
-
 file(GLOB CUDA_SOURCES RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} "*.cu" "*.cc")
 list(FILTER CUDA_SOURCES EXCLUDE REGEX "pybind.*")
 file(GLOB CUDA_HEADERS RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} "*.cuh" "*.h")
 list(FILTER CUDA_HEADERS EXCLUDE REGEX "pybind.*")
 
-cuda_add_library({{caslib.name}}_core STATIC ${CUDA_SOURCES} ${CUDA_HEADERS})
+add_library({{caslib.name}}_core STATIC ${CUDA_SOURCES} ${CUDA_HEADERS})
 target_include_directories({{caslib.name}}_core PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+target_compile_options({{caslib.name}}_core PRIVATE
+  $<$<COMPILE_LANGUAGE:CUDA>:--use_fast_math>
+)
 set_target_properties({{caslib.name}}_core PROPERTIES
-    POSITION_INDEPENDENT_CODE ON
-    CUDA_SEPARABLE_COMPILATION ON
+  POSITION_INDEPENDENT_CODE ON
 )
 
 file(GLOB CPP_SOURCES "pybind*.cc")
@@ -44,6 +55,6 @@ pybind11_add_module({{caslib.name}} ${CPP_SOURCES} ${CPP_HEADERS})
 target_link_libraries({{caslib.name}} PRIVATE {{caslib.name}}_core)
 
 set_target_properties({{caslib.name}} PROPERTIES
-    LIBRARY_OUTPUT_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-    RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+  LIBRARY_OUTPUT_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+  RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 )

--- a/symforce/caspar/source/templates/buildfiles/CMakeLists.txt.jinja
+++ b/symforce/caspar/source/templates/buildfiles/CMakeLists.txt.jinja
@@ -12,11 +12,7 @@ project(caspar_library LANGUAGES CXX CUDA)
 
 # SASS for Turing/Ampere/Ada (sm_75–89) + PTX fallback for forward JIT-compatibility. sm_75 minimum required by cooperative_groups::reduce.
 if(NOT DEFINED CMAKE_CUDA_ARCHITECTURES)
-  if(CMAKE_VERSION VERSION_GREATER_EQUAL "3.24")
-    set(CMAKE_CUDA_ARCHITECTURES native)
-  else()
-    set(CMAKE_CUDA_ARCHITECTURES 75 80 86 89 75-virtual)
-  endif()
+  set(CMAKE_CUDA_ARCHITECTURES 75 80 86 89 75-virtual)
 endif()
 
 find_package(CUDAToolkit REQUIRED)


### PR DESCRIPTION
- Replaces deprecated FindCUDA with CMake's native CUDA language support (requires CMake 3.18)
- Fixes non-portable behavior from -arch=sm_75. It embeds only sm_75 SASS with no PTX, so on newer architectures the driver silently falls back to running Turing SASS under backward compatibility. I experienced that results can differ across GPU generations when this flag was set. The new CMAKE_CUDA_ARCHITECTURES embeds SASS for sm_75/80/86/89 and PTX for forward JIT-compatibility on future architectures. The logic is to by default have maximum compatability, and let the user specify the specific arch if they want to reduce binary size etc.
- Respects CUDACXX env var before project() to handle systems with conflicting CUDA installations
- CasparLibrary.compile() gains cuda_architectures and jobs parameters. The latter defaults to a single job to avoid OOM on machines where parallel CUDA compilation exhausts RAM (I only have 16gig rn, so this was an issue even with just a small amount of kernels)
- Fixes CMake dev warning by adding DOWNLOAD_EXTRACT_TIMESTAMP TRUE to the pybind11 FetchContent_Declare
- Some minor improvements to the compile() function hopefully making it easier to build

I have tested this on sm_86 and sm_89 GPUs. 