### PR TITLE
[Caspar] Python bindings opt-out

### DIFF
--- a/symforce/caspar/code_generation/library.py
+++ b/symforce/caspar/code_generation/library.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import logging
 import shutil
+import subprocess
 from pathlib import Path
 
 from symforce import caspar
@@ -147,17 +148,24 @@ class CasparLibrary:
         self.generate_kernels(out_dir)
 
     @staticmethod
-    def compile(out_dir: Path, debug: bool = False) -> None:
-        import subprocess
-
+    def compile(
+        out_dir: Path,
+        debug: bool = False,
+        cuda_architectures: str | None = None,
+        jobs: int | None = None,
+    ) -> None:
         build_dir = out_dir / "build"
         build_dir.mkdir(exist_ok=True)
         logging.info(f"Compiling {out_dir}")
-        if debug:
-            subprocess.run(["cmake", "-DCMAKE_BUILD_TYPE=Debug", ".."], cwd=build_dir, check=True)
-        else:
-            subprocess.run(["cmake", "-DCMAKE_BUILD_TYPE=Release", ".."], cwd=build_dir, check=True)
-        subprocess.run(["make", "-j"], cwd=build_dir, check=True)
+        cmake_args = ["cmake", f"-DCMAKE_BUILD_TYPE={'Debug' if debug else 'Release'}"]
+        if cuda_architectures is not None:
+            cmake_args.append(f"-DCMAKE_CUDA_ARCHITECTURES={cuda_architectures}")
+        cmake_args.append("..")
+        subprocess.run(cmake_args, cwd=build_dir, check=True)
+        build_args = ["cmake", "--build", "."]
+        if jobs is not None:
+            build_args += ["--parallel", str(jobs)]
+        subprocess.run(build_args, cwd=build_dir, check=True)
 
     # This function has no annotated return type, so that type inference in IDEs can get more
     # specific typing than ModuleType

--- a/symforce/caspar/code_generation/library.py
+++ b/symforce/caspar/code_generation/library.py
@@ -150,20 +150,23 @@ class CasparLibrary:
             insert_sorted_unique(self.exposed_types, factor.arg_types.values())
             return func_or_name
 
-    def generate(self, out_dir: Path, use_symlinks: bool = False) -> None:
+    def generate(
+        self, out_dir: Path, use_symlinks: bool = False, python_bindings: bool = True
+    ) -> None:
         out_dir.mkdir(exist_ok=True, parents=True)
 
         for fac in self.factors:
             self.kernels.extend(fac.make_kernels())
 
-        self.generate_castype_mappings(out_dir)
+        self.generate_castype_mappings(out_dir, python_bindings)
         self.generate_links(out_dir, use_symlinks)
         if solver := (Solver(self) if self.factors else None):
             self.kernels.extend(solver.make_kernels())
-            solver.generate(out_dir)
-        self.generate_binding_file(out_dir, solver)
-        self.generate_stubs(out_dir, solver)
-        self.generate_buildfiles(out_dir)
+            solver.generate(out_dir, python_bindings)
+        if python_bindings:
+            self.generate_binding_file(out_dir, solver)
+            self.generate_stubs(out_dir, solver)
+        self.generate_buildfiles(out_dir, python_bindings)
         self.generate_kernels(out_dir)
 
     @staticmethod
@@ -246,7 +249,7 @@ class CasparLibrary:
             else:
                 copy_if_different(f, f_new)
 
-    def generate_castype_mappings(self, out_dir: Path) -> None:
+    def generate_castype_mappings(self, out_dir: Path, python_bindings: bool = True) -> None:
         """
         Generates code to perform mapping between stacked format (array of structs)
         and the caspar layout of the corresponding types.
@@ -263,14 +266,15 @@ class CasparLibrary:
         write_if_different(definition, out_dir.joinpath("caspar_mappings.cu"))
         definition = env.get_template("caspar_mappings.h.jinja").render(**kwargs)
         write_if_different(definition, out_dir.joinpath("caspar_mappings.h"))
-        definition = env.get_template("caspar_mappings_pybinding.h.jinja").render(**kwargs)
-        write_if_different(definition, out_dir.joinpath("caspar_mappings_pybinding.h"))
+        if python_bindings:
+            definition = env.get_template("caspar_mappings_pybinding.h.jinja").render(**kwargs)
+            write_if_different(definition, out_dir.joinpath("caspar_mappings_pybinding.h"))
 
     def generate_binding_file(self, out_dir: Path, solver: Solver | None) -> None:
         binding = env.get_template("pybinding.cc.jinja").render(caslib=self, solver=solver)
         write_if_different(binding, out_dir.joinpath("pybinding.cc"))
 
-    def generate_buildfiles(self, out_dir: Path) -> None:
+    def generate_buildfiles(self, out_dir: Path, python_bindings: bool = True) -> None:
         for template in env.list_templates(filter_func=lambda t: t.startswith("buildfiles")):
-            content = env.get_template(template).render(caslib=self)
+            content = env.get_template(template).render(caslib=self, python_bindings=python_bindings)
             write_if_different(content, out_dir.joinpath(Path(template).stem))

--- a/symforce/caspar/code_generation/library.py
+++ b/symforce/caspar/code_generation/library.py
@@ -49,6 +49,25 @@ def insert_sorted_unique(
             container.insert(lo, item)
 
 
+def _real_cuda_arch_string() -> str:
+    """Return a CMake CUDA_ARCHITECTURES string with SASS-only targets for all detected GPUs.
+
+    Using -real (no PTX embedding) avoids cudaErrorUnsupportedPtxVersion when the nvcc version
+    exceeds the installed CUDA driver version.
+    """
+    try:
+        out = subprocess.run(
+            ["nvidia-smi", "--query-gpu=compute_cap", "--format=csv,noheader"],
+            capture_output=True, text=True, check=True, timeout=10,
+        ).stdout
+        caps = sorted({cap.replace(".", "") for cap in out.strip().splitlines() if cap.strip()})
+        if caps:
+            return ";".join(f"{cap}-real" for cap in caps)
+    except Exception:
+        pass
+    return "native"
+
+
 class CasparLibrary:
     """
     The CasLib class is the main entry point for generating and compiling caspar libraries.
@@ -151,21 +170,20 @@ class CasparLibrary:
     def compile(
         out_dir: Path,
         debug: bool = False,
-        cuda_architectures: str | None = None,
+        cuda_arch: str | None = None,
         jobs: int | None = None,
     ) -> None:
         build_dir = out_dir / "build"
-        build_dir.mkdir(exist_ok=True)
-        logging.info(f"Compiling {out_dir}")
-        cmake_args = ["cmake", f"-DCMAKE_BUILD_TYPE={'Debug' if debug else 'Release'}"]
-        if cuda_architectures is not None:
-            cmake_args.append(f"-DCMAKE_CUDA_ARCHITECTURES={cuda_architectures}")
-        cmake_args.append("..")
-        subprocess.run(cmake_args, cwd=build_dir, check=True)
-        build_args = ["cmake", "--build", "."]
-        if jobs is not None:
-            build_args += ["--parallel", str(jobs)]
-        subprocess.run(build_args, cwd=build_dir, check=True)
+        config_cmd = [
+            "cmake", "-S", out_dir, "-B", build_dir,
+            f"-DCMAKE_BUILD_TYPE={'Debug' if debug else 'Release'}",
+            f"-DCMAKE_CUDA_ARCHITECTURES={cuda_arch if cuda_arch is not None else _real_cuda_arch_string()}",
+        ]
+        subprocess.run(config_cmd, check=True)
+        build_cmd = ["cmake", "--build", build_dir, "--parallel"]
+        if jobs:
+            build_cmd.append(str(jobs))
+        subprocess.run(build_cmd, check=True)
 
     # This function has no annotated return type, so that type inference in IDEs can get more
     # specific typing than ModuleType

--- a/symforce/caspar/code_generation/library.py
+++ b/symforce/caspar/code_generation/library.py
@@ -163,7 +163,7 @@ class CasparLibrary:
             self.kernels.extend(fac.make_kernels())
 
         self.generate_castype_mappings(out_dir, python_bindings)
-        self.generate_links(out_dir, use_symlinks)
+        self.generate_links(out_dir, use_symlinks, python_bindings)
         if solver := (Solver(self) if self.factors else None):
             self.kernels.extend(solver.make_kernels())
             solver.generate(out_dir, python_bindings)
@@ -245,9 +245,13 @@ class CasparLibrary:
             kernel.generate(out_dir)
 
     @staticmethod
-    def generate_links(out_dir: Path, use_symlinks: bool = True) -> None:
+    def generate_links(
+        out_dir: Path, use_symlinks: bool = True, python_bindings: bool = True
+    ) -> None:
         for f in Path(caspar.__file__).parent.glob("source/runtime/*"):
             if f.is_dir():  # Skip directories like __pycache__
+                continue
+            if not python_bindings and "pybind" in f.name:
                 continue
             f_new = out_dir / f.name
             if use_symlinks:

--- a/symforce/caspar/code_generation/solver.py
+++ b/symforce/caspar/code_generation/solver.py
@@ -669,7 +669,7 @@ class Solver:
             )
         return list(self.kernels.values())
 
-    def generate(self, out_dir: Path) -> None:
+    def generate(self, out_dir: Path, python_bindings: bool = True) -> None:
         kwargs = dict(
             solver=self,
             name_key=name_key,
@@ -688,5 +688,6 @@ class Solver:
         write_if_different(header, out_dir.joinpath("solver.h"))
         definition = env.get_template("solver.cc.jinja").render(**kwargs)
         write_if_different(definition, out_dir.joinpath("solver.cc"))
-        definition = env.get_template("solver_pybinding.h.jinja").render(**kwargs)
-        write_if_different(definition, out_dir.joinpath("solver_pybinding.h"))
+        if python_bindings:
+            definition = env.get_template("solver_pybinding.h.jinja").render(**kwargs)
+            write_if_different(definition, out_dir.joinpath("solver_pybinding.h"))

--- a/symforce/caspar/source/templates/buildfiles/CMakeLists.txt.jinja
+++ b/symforce/caspar/source/templates/buildfiles/CMakeLists.txt.jinja
@@ -17,19 +17,23 @@ endif()
 
 find_package(CUDAToolkit REQUIRED)
 
-include(FetchContent)
-find_package(pybind11 2.13.6 QUIET)
-if(NOT pybind11_FOUND)
-  message(STATUS "pybind11 not found, adding with FetchContent")
-  FetchContent_Declare(
-    pybind11
-    URL https://github.com/pybind/pybind11/archive/v2.13.6.zip
-    URL_HASH SHA256=d0a116e91f64a4a2d8fb7590c34242df92258a61ec644b79127951e821b47be6
-    DOWNLOAD_EXTRACT_TIMESTAMP TRUE
-  )
-  FetchContent_MakeAvailable(pybind11)
-else()
-  message(STATUS "pybind11 found")
+option(CASPAR_BUILD_PYTHON_BINDINGS "Build Python bindings via pybind11" ON)
+
+if(CASPAR_BUILD_PYTHON_BINDINGS)
+  include(FetchContent)
+  find_package(pybind11 2.13.6 QUIET)
+  if(NOT pybind11_FOUND)
+    message(STATUS "pybind11 not found, adding with FetchContent")
+    FetchContent_Declare(
+      pybind11
+      URL https://github.com/pybind/pybind11/archive/v2.13.6.zip
+      URL_HASH SHA256=d0a116e91f64a4a2d8fb7590c34242df92258a61ec644b79127951e821b47be6
+      DOWNLOAD_EXTRACT_TIMESTAMP TRUE
+    )
+    FetchContent_MakeAvailable(pybind11)
+  else()
+    message(STATUS "pybind11 found")
+  endif()
 endif()
 
 file(GLOB CUDA_SOURCES RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} "*.cu" "*.cc")
@@ -47,13 +51,14 @@ set_target_properties({{caslib.name}}_core PROPERTIES
   POSITION_INDEPENDENT_CODE ON
 )
 
-file(GLOB CPP_SOURCES "pybind*.cc")
-file(GLOB CPP_HEADERS "*.h")
+if(CASPAR_BUILD_PYTHON_BINDINGS)
+  file(GLOB CPP_SOURCES "pybind*.cc")
 
-pybind11_add_module({{caslib.name}} ${CPP_SOURCES} ${CPP_HEADERS})
-target_link_libraries({{caslib.name}} PRIVATE {{caslib.name}}_core)
+  pybind11_add_module({{caslib.name}} ${CPP_SOURCES})
+  target_link_libraries({{caslib.name}} PRIVATE {{caslib.name}}_core)
 
-set_target_properties({{caslib.name}} PROPERTIES
-  LIBRARY_OUTPUT_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-  RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-)
+  set_target_properties({{caslib.name}} PROPERTIES
+    LIBRARY_OUTPUT_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+  )
+endif()

--- a/symforce/caspar/source/templates/buildfiles/CMakeLists.txt.jinja
+++ b/symforce/caspar/source/templates/buildfiles/CMakeLists.txt.jinja
@@ -19,6 +19,8 @@ if(NOT DEFINED CMAKE_CUDA_ARCHITECTURES)
   endif()
 endif()
 
+find_package(CUDAToolkit REQUIRED)
+
 include(FetchContent)
 find_package(pybind11 2.13.6 QUIET)
 if(NOT pybind11_FOUND)
@@ -41,6 +43,7 @@ list(FILTER CUDA_HEADERS EXCLUDE REGEX "pybind.*")
 
 add_library({{caslib.name}}_core STATIC ${CUDA_SOURCES} ${CUDA_HEADERS})
 target_include_directories({{caslib.name}}_core PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+target_link_libraries({{caslib.name}}_core PUBLIC CUDA::cudart)
 target_compile_options({{caslib.name}}_core PRIVATE
   $<$<COMPILE_LANGUAGE:CUDA>:--use_fast_math>
 )

--- a/symforce/caspar/source/templates/buildfiles/CMakeLists.txt.jinja
+++ b/symforce/caspar/source/templates/buildfiles/CMakeLists.txt.jinja
@@ -2,39 +2,50 @@
  # SymForce - Copyright 2025, Skydio, Inc.
  # This source code is under the Apache 2.0 license found in the LICENSE file.
  # ---------------------------------------------------------------------------- #}
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.18)
 
-project(caspar_library LANGUAGES CXX)
-set(CUDA_TOOLKIT_ROOT_DIR /usr/local/cuda)
+if(NOT DEFINED CMAKE_CUDA_COMPILER AND DEFINED ENV{CUDACXX})
+  set(CMAKE_CUDA_COMPILER "$ENV{CUDACXX}" CACHE FILEPATH "CUDA compiler")
+endif()
 
-find_package(CUDA REQUIRED)
+project(caspar_library LANGUAGES CXX CUDA)
+
+# SASS for Turing/Ampere/Ada (sm_75–89) + PTX fallback for forward JIT-compatibility. sm_75 minimum required by cooperative_groups::reduce.
+if(NOT DEFINED CMAKE_CUDA_ARCHITECTURES)
+  if(CMAKE_VERSION VERSION_GREATER_EQUAL "3.24")
+    set(CMAKE_CUDA_ARCHITECTURES native)
+  else()
+    set(CMAKE_CUDA_ARCHITECTURES 75 80 86 89 75-virtual)
+  endif()
+endif()
+
 include(FetchContent)
 find_package(pybind11 2.13.6 QUIET)
-if (NOT pybind11_FOUND)
+if(NOT pybind11_FOUND)
   message(STATUS "pybind11 not found, adding with FetchContent")
   FetchContent_Declare(
     pybind11
     URL https://github.com/pybind/pybind11/archive/v2.13.6.zip
     URL_HASH SHA256=d0a116e91f64a4a2d8fb7590c34242df92258a61ec644b79127951e821b47be6
+    DOWNLOAD_EXTRACT_TIMESTAMP TRUE
   )
   FetchContent_MakeAvailable(pybind11)
 else()
   message(STATUS "pybind11 found")
 endif()
 
-set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS} --use_fast_math -arch=sm_75")
-set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS} -Xcompiler -fPIC")
-
 file(GLOB CUDA_SOURCES RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} "*.cu" "*.cc")
 list(FILTER CUDA_SOURCES EXCLUDE REGEX "pybind.*")
 file(GLOB CUDA_HEADERS RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} "*.cuh" "*.h")
 list(FILTER CUDA_HEADERS EXCLUDE REGEX "pybind.*")
 
-cuda_add_library({{caslib.name}}_core STATIC ${CUDA_SOURCES} ${CUDA_HEADERS})
+add_library({{caslib.name}}_core STATIC ${CUDA_SOURCES} ${CUDA_HEADERS})
 target_include_directories({{caslib.name}}_core PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+target_compile_options({{caslib.name}}_core PRIVATE
+  $<$<COMPILE_LANGUAGE:CUDA>:--use_fast_math>
+)
 set_target_properties({{caslib.name}}_core PROPERTIES
-    POSITION_INDEPENDENT_CODE ON
-    CUDA_SEPARABLE_COMPILATION ON
+  POSITION_INDEPENDENT_CODE ON
 )
 
 file(GLOB CPP_SOURCES "pybind*.cc")
@@ -44,6 +55,6 @@ pybind11_add_module({{caslib.name}} ${CPP_SOURCES} ${CPP_HEADERS})
 target_link_libraries({{caslib.name}} PRIVATE {{caslib.name}}_core)
 
 set_target_properties({{caslib.name}} PROPERTIES
-    LIBRARY_OUTPUT_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-    RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+  LIBRARY_OUTPUT_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+  RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 )

--- a/symforce/caspar/source/templates/buildfiles/CMakeLists.txt.jinja
+++ b/symforce/caspar/source/templates/buildfiles/CMakeLists.txt.jinja
@@ -17,6 +17,7 @@ endif()
 
 find_package(CUDAToolkit REQUIRED)
 
+{% if python_bindings %}
 option(CASPAR_BUILD_PYTHON_BINDINGS "Build Python bindings via pybind11" ON)
 
 if(CASPAR_BUILD_PYTHON_BINDINGS)
@@ -36,6 +37,7 @@ if(CASPAR_BUILD_PYTHON_BINDINGS)
   endif()
 endif()
 
+{% endif %}
 file(GLOB CUDA_SOURCES RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} "*.cu" "*.cc")
 list(FILTER CUDA_SOURCES EXCLUDE REGEX "pybind.*")
 file(GLOB CUDA_HEADERS RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} "*.cuh" "*.h")
@@ -51,6 +53,7 @@ set_target_properties({{caslib.name}}_core PROPERTIES
   POSITION_INDEPENDENT_CODE ON
 )
 
+{% if python_bindings %}
 if(CASPAR_BUILD_PYTHON_BINDINGS)
   file(GLOB CPP_SOURCES "pybind*.cc")
 
@@ -62,3 +65,4 @@ if(CASPAR_BUILD_PYTHON_BINDINGS)
     RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
   )
 endif()
+{% endif %}

--- a/symforce/caspar/source/templates/buildfiles/CMakeLists.txt.jinja
+++ b/symforce/caspar/source/templates/buildfiles/CMakeLists.txt.jinja
@@ -12,11 +12,7 @@ project(caspar_library LANGUAGES CXX CUDA)
 
 # SASS for Turing/Ampere/Ada (sm_75–89) + PTX fallback for forward JIT-compatibility. sm_75 minimum required by cooperative_groups::reduce.
 if(NOT DEFINED CMAKE_CUDA_ARCHITECTURES)
-  if(CMAKE_VERSION VERSION_GREATER_EQUAL "3.24")
-    set(CMAKE_CUDA_ARCHITECTURES native)
-  else()
-    set(CMAKE_CUDA_ARCHITECTURES 75 80 86 89 75-virtual)
-  endif()
+  set(CMAKE_CUDA_ARCHITECTURES 75 80 86 89 75-virtual)
 endif()
 
 find_package(CUDAToolkit REQUIRED)

--- a/symforce/caspar/source/templates/buildfiles/CMakeLists.txt.jinja
+++ b/symforce/caspar/source/templates/buildfiles/CMakeLists.txt.jinja
@@ -57,7 +57,7 @@ set_target_properties({{caslib.name}}_core PROPERTIES
 if(CASPAR_BUILD_PYTHON_BINDINGS)
   file(GLOB CPP_SOURCES "pybind*.cc")
 
-  pybind11_add_module({{caslib.name}} ${CPP_SOURCES})
+  pybind11_add_module({{caslib.name}} ${CPP_SOURCES} ${CPP_HEADERS})
   target_link_libraries({{caslib.name}} PRIVATE {{caslib.name}}_core)
 
   set_target_properties({{caslib.name}} PROPERTIES


### PR DESCRIPTION
Projects embedding only the CXX/CUDA core of Caspar (e.g. via ExternalProject_Add) can now skip pybind11 entirely:
- `CasparLibrary.generate(..., python_bindings=False)` skips generating pybinding.cc, caspar_mappings_pybinding.h, solver_pybinding.h, and .pyi stubs
- The generated CMakeLists.txt omits the pybind11 find/fetch block and pybind11_add_module target entirely when python_bindings=False
- When python_bindings=True (default), a CASPAR_BUILD_PYTHON_BINDINGS CMake option is still emitted for compile-time opt-out
- All existing callers are unaffected since the default is True

Blocked by #457 and requested by https://github.com/colmap/colmap/pull/4018 such that we don't have to manually remove python bindings when regenerating. 
