### PR TITLE
[Caspar] Minor fix: Export CASPAR_MIN_ARCH and fix CUDA architecture list in Caspar template

### DIFF
--- a/symforce/caspar/source/templates/buildfiles/CMakeLists.txt.jinja
+++ b/symforce/caspar/source/templates/buildfiles/CMakeLists.txt.jinja
@@ -10,9 +10,11 @@ endif()
 
 project(caspar_library LANGUAGES CXX CUDA)
 
+set(CASPAR_MIN_ARCH 75 CACHE INTERNAL "Minimum CUDA arch required by Caspar")
+
 # SASS for Turing/Ampere/Ada (sm_75–89) + PTX fallback for forward JIT-compatibility. sm_75 minimum required by cooperative_groups::reduce.
 if(NOT DEFINED CMAKE_CUDA_ARCHITECTURES)
-  set(CMAKE_CUDA_ARCHITECTURES 75 80 86 89 75-virtual)
+  set(CMAKE_CUDA_ARCHITECTURES ${CASPAR_MIN_ARCH} 80-real 86-real 89-real)
 endif()
 
 find_package(CUDAToolkit REQUIRED)


### PR DESCRIPTION
CASPAR_MIN_ARCH was previously a local CMake variable, invisible to parent projects consuming Caspar via FetchContent. This change makes it a CACHE INTERNAL variable so downstream consumers (e.g. COLMAP) can read it after FetchContent_MakeAvailable(caspar) without hardcoding the value.

Also fixes the CMAKE_CUDA_ARCHITECTURES list: the previous 75 80 86 89 75-virtual generated PTX for all four architectures and emitted compute_75 twice. The corrected list 75 80-real 86-real 89-real generates SASS for all and PTX only from sm_75, matching the stated intent.